### PR TITLE
Time based X axis limits. Zooming. Smoothness. 

### DIFF
--- a/src/ConfigHandler/ConfigHandler.cpp
+++ b/src/ConfigHandler/ConfigHandler.cpp
@@ -52,7 +52,7 @@ bool ConfigHandler::readConfigFile(std::map<std::string, std::shared_ptr<Variabl
 	getValue("settings", "version", globalSettings.version);
 	getValue("settings", "sample_frequency_Hz", viewerSettings.sampleFrequencyHz);
 	getValue("settings", "max_points", viewerSettings.maxPoints);
-	getValue("settings", "max_viewport_points", viewerSettings.maxViewportPoints);
+	getValue("settings", "max_viewport_points", viewerSettings.maxViewportTime);
 	getValue("settings", "probe_type", probeSettings.debugProbe);
 	probeSettings.device = ini->get("settings").get("target_name");
 	getValue("settings", "probe_mode", probeSettings.mode);
@@ -86,8 +86,8 @@ bool ConfigHandler::readConfigFile(std::map<std::string, std::shared_ptr<Variabl
 	if (viewerSettings.maxPoints == 0)
 		viewerSettings.maxPoints = 1000;
 
-	if (viewerSettings.maxViewportPoints == 0)
-		viewerSettings.maxViewportPoints = viewerSettings.maxPoints;
+	if (viewerSettings.maxViewportTime == 0)
+		viewerSettings.maxViewportTime = 1;
 
 	if (probeSettings.speedkHz == 0)
 		probeSettings.speedkHz = 100;
@@ -219,7 +219,7 @@ bool ConfigHandler::saveConfigFile(std::map<std::string, std::shared_ptr<Variabl
 
 	(*ini)["settings"]["sample_frequency_hz"] = std::to_string(viewerSettings.sampleFrequencyHz);
 	(*ini)["settings"]["max_points"] = std::to_string(viewerSettings.maxPoints);
-	(*ini)["settings"]["max_viewport_points"] = std::to_string(viewerSettings.maxViewportPoints);
+	(*ini)["settings"]["max_viewport_points"] = std::to_string(viewerSettings.maxViewportTime);
 	(*ini)["settings"]["probe_type"] = std::to_string(probeSettings.debugProbe);
 	(*ini)["settings"]["target_name"] = probeSettings.device;
 	(*ini)["settings"]["probe_mode"] = std::to_string(probeSettings.mode);

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -103,7 +103,7 @@ void Gui::mainThread()
 		}
 
 		if (glfwGetWindowAttrib(window, GLFW_FOCUSED) || (tracePlotHandler->getViewerState() == PlotHandlerBase::state::RUN) || (plotHandler->getViewerState() == PlotHandlerBase::state::RUN))
-			glfwSwapInterval(2);
+			glfwSwapInterval(1);
 		else
 			glfwSwapInterval(4);
 

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -859,12 +859,11 @@ void Gui::acqusitionSettingsViewer()
 	ImGui::HelpMarker("Max points used for a single series after which the oldest points will be overwritten.");
 	settings.maxPoints = std::clamp(settings.maxPoints, minPoints, maxPoints);
 
-	ImGui::Text("Max view points:                   ");
+	ImGui::Text("Max view time[s]:                  ");
 	ImGui::SameLine();
-	ImGui::InputScalar("##maxViewportPoints", ImGuiDataType_U32, &settings.maxViewportPoints, NULL, NULL, "%u");
+	ImGui::InputScalar("##maxViewportTime", ImGuiDataType_U32, &settings.maxViewportTime, NULL, NULL, "%u");
 	ImGui::SameLine();
-	ImGui::HelpMarker("Max points used for a single series that will be shown in the viewport without scroling.");
-	settings.maxViewportPoints = std::clamp(settings.maxViewportPoints, minPoints, settings.maxPoints);
+	ImGui::HelpMarker("Max time used that will be shown in the viewport without scrolling.");
 
 	plotHandler->setSettings(settings);
 

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -859,7 +859,7 @@ void Gui::acqusitionSettingsViewer()
 	ImGui::HelpMarker("Max points used for a single series after which the oldest points will be overwritten.");
 	settings.maxPoints = std::clamp(settings.maxPoints, minPoints, maxPoints);
 
-	ImGui::Text("Max view time[s]:                  ");
+	ImGui::Text("Default viewport time[s]:          ");
 	ImGui::SameLine();
 	ImGui::InputScalar("##maxViewportTime", ImGuiDataType_U32, &settings.maxViewportTime, NULL, NULL, "%u");
 	ImGui::SameLine();

--- a/src/Gui/GuiPlots.cpp
+++ b/src/Gui/GuiPlots.cpp
@@ -81,27 +81,23 @@ void Gui::drawPlotCurve(Plot* plot, ScrollingBuffer<double>& time, std::map<std:
 	if (ImPlot::BeginPlot(plot->getName().c_str(), ImVec2(-1, -1), ImPlotFlags_None))
 	{
 		static std::chrono::time_point<std::chrono::steady_clock> start;
-		auto finish = std::chrono::steady_clock::now();
-		const double acquisitionTime = std::chrono::duration_cast<std::chrono::duration<double>>(finish - start).count();
-		
+		PlotHandler::Settings settings = plotHandler->getSettings();
+		static double viewportWidth = settings.maxViewportTime;
 		if (plotHandler->getViewerState() == PlotHandler::state::RUN)
 		{
-			PlotHandler::Settings settings = plotHandler->getSettings();
-			ImPlot::SetupAxis(ImAxis_Y1, NULL, ImPlotAxisFlags_AutoFit);
-			ImPlot::SetupAxis(ImAxis_X1, "time[s]", 0);
-			const double viewportWidth = settings.maxViewportTime;
-			
+			auto finish = std::chrono::steady_clock::now();
+			const double acquisitionTime = std::chrono::duration_cast<std::chrono::duration<double>>(finish - start).count();
 			const double min = acquisitionTime < viewportWidth ? 0.0f : acquisitionTime - viewportWidth;
-			const double max = min == 0.0f ? acquisitionTime : min + viewportWidth;
+			const double max = min + viewportWidth;
 			ImPlot::SetupAxisLimits(ImAxis_X1, min, max, ImPlotCond_Always); 
 		}
 		else
 		{
-			ImPlot::SetupAxes("time[s]", NULL, 0, 0);
-			ImPlot::SetupAxisLimits(ImAxis_X1, -1, 10, ImPlotCond_Once);
-			ImPlot::SetupAxisLimits(ImAxis_Y1, -0.1, 0.1, ImPlotCond_Once);
 			start = std::chrono::steady_clock::now(); //there is a bit of a delay between end of stop and timeseries time
 		}
+		ImPlot::SetupAxes("time[s]",NULL, 0, ImPlotAxisFlags_AutoFit);
+		ImPlot::SetupAxisLimits(ImAxis_X1, 0, viewportWidth, ImPlotCond_Once);
+		viewportWidth = ImPlot::GetPlotLimits().X.Size();
 
 		plot->setIsHovered(ImPlot::IsPlotHovered());
 

--- a/src/Gui/GuiPlots.cpp
+++ b/src/Gui/GuiPlots.cpp
@@ -80,21 +80,22 @@ void Gui::drawPlotCurve(Plot* plot, ScrollingBuffer<double>& time, std::map<std:
 {
 	if (ImPlot::BeginPlot(plot->getName().c_str(), ImVec2(-1, -1), ImPlotFlags_None))
 	{
-		static std::chrono::time_point<std::chrono::steady_clock> start;
+		
 		PlotHandler::Settings settings = plotHandler->getSettings();
 		static double viewportWidth = settings.maxViewportTime;
+		static PlotHandler::state viewerStatePrev = PlotHandler::state::STOP;
 		if (plotHandler->getViewerState() == PlotHandler::state::RUN)
-		{
+		{	
+			static std::chrono::time_point<std::chrono::steady_clock> start;
+			if (viewerStatePrev == PlotHandler::state::STOP)
+				start = std::chrono::steady_clock::now();
 			auto finish = std::chrono::steady_clock::now();
 			const double acquisitionTime = std::chrono::duration_cast<std::chrono::duration<double>>(finish - start).count();
 			const double min = acquisitionTime < viewportWidth ? 0.0f : acquisitionTime - viewportWidth;
 			const double max = min + viewportWidth;
 			ImPlot::SetupAxisLimits(ImAxis_X1, min, max, ImPlotCond_Always); 
 		}
-		else
-		{
-			start = std::chrono::steady_clock::now(); //there is a bit of a delay between end of stop and timeseries time
-		}
+		viewerStatePrev = plotHandler->getViewerState();
 		ImPlot::SetupAxes("time[s]",NULL, 0, ImPlotAxisFlags_AutoFit);
 		ImPlot::SetupAxisLimits(ImAxis_X1, 0, viewportWidth, ImPlotCond_Once);
 		viewportWidth = ImPlot::GetPlotLimits().X.Size();

--- a/src/Gui/GuiPlots.cpp
+++ b/src/Gui/GuiPlots.cpp
@@ -78,7 +78,7 @@ void Gui::drawPlots()
 
 void Gui::drawPlotCurve(Plot* plot, ScrollingBuffer<double>& time, std::map<std::string, std::shared_ptr<Plot::Series>>& seriesMap, uint32_t curveBarPlots)
 {
-	if (ImPlot::BeginPlot(plot->getName().c_str(), ImVec2(-1, -1), ImPlotFlags_NoChild))
+	if (ImPlot::BeginPlot(plot->getName().c_str(), ImVec2(-1, -1), ImPlotFlags_None))
 	{
 		if (plotHandler->getViewerState() == PlotHandler::state::RUN)
 		{
@@ -154,7 +154,7 @@ void Gui::drawPlotCurve(Plot* plot, ScrollingBuffer<double>& time, std::map<std:
 }
 void Gui::drawPlotBar(Plot* plot, ScrollingBuffer<double>& time, std::map<std::string, std::shared_ptr<Plot::Series>>& seriesMap, uint32_t curveBarPlots)
 {
-	if (ImPlot::BeginPlot(plot->getName().c_str(), ImVec2(-1, -1), ImPlotFlags_NoChild))
+	if (ImPlot::BeginPlot(plot->getName().c_str(), ImVec2(-1, -1), ImPlotFlags_None))
 	{
 		std::vector<const char*> glabels;
 		std::vector<double> positions;

--- a/src/Gui/GuiPlots.cpp
+++ b/src/Gui/GuiPlots.cpp
@@ -80,21 +80,27 @@ void Gui::drawPlotCurve(Plot* plot, ScrollingBuffer<double>& time, std::map<std:
 {
 	if (ImPlot::BeginPlot(plot->getName().c_str(), ImVec2(-1, -1), ImPlotFlags_None))
 	{
+		static std::chrono::time_point<std::chrono::steady_clock> start;
+		auto finish = std::chrono::steady_clock::now();
+		const double acquisitionTime = std::chrono::duration_cast<std::chrono::duration<double>>(finish - start).count();
+		
 		if (plotHandler->getViewerState() == PlotHandler::state::RUN)
 		{
 			PlotHandler::Settings settings = plotHandler->getSettings();
 			ImPlot::SetupAxis(ImAxis_Y1, NULL, ImPlotAxisFlags_AutoFit);
 			ImPlot::SetupAxis(ImAxis_X1, "time[s]", 0);
-			const double viewportWidth = (1.0 / plotHandler->getAverageSamplingFrequency()) * settings.maxViewportPoints;
-			const double min = *time.getLastElement() < viewportWidth ? 0.0f : *time.getLastElement() - viewportWidth;
-			const double max = min == 0.0f ? *time.getLastElement() : min + viewportWidth;
-			ImPlot::SetupAxisLimits(ImAxis_X1, min, max, ImPlotCond_Always);
+			const double viewportWidth = settings.maxViewportTime;
+			
+			const double min = acquisitionTime < viewportWidth ? 0.0f : acquisitionTime - viewportWidth;
+			const double max = min == 0.0f ? acquisitionTime : min + viewportWidth;
+			ImPlot::SetupAxisLimits(ImAxis_X1, min, max, ImPlotCond_Always); 
 		}
 		else
 		{
 			ImPlot::SetupAxes("time[s]", NULL, 0, 0);
 			ImPlot::SetupAxisLimits(ImAxis_X1, -1, 10, ImPlotCond_Once);
 			ImPlot::SetupAxisLimits(ImAxis_Y1, -0.1, 0.1, ImPlotCond_Once);
+			start = std::chrono::steady_clock::now(); //there is a bit of a delay between end of stop and timeseries time
 		}
 
 		plot->setIsHovered(ImPlot::IsPlotHovered());
@@ -148,7 +154,6 @@ void Gui::drawPlotCurve(Plot* plot, ScrollingBuffer<double>& time, std::map<std:
 				ImPlot::PlotScatter("###point", &timepoint, &value, 1, false);
 			}
 		}
-
 		ImPlot::EndPlot();
 	}
 }

--- a/src/PlotHandler/PlotHandler.hpp
+++ b/src/PlotHandler/PlotHandler.hpp
@@ -23,7 +23,7 @@ class PlotHandler : public PlotHandlerBase
 	{
 		uint32_t sampleFrequencyHz = 100;
 		uint32_t maxPoints = 10000;
-		uint32_t maxViewportPoints = 5000;
+		uint32_t maxViewportTime = 5;
 		bool refreshAddressesOnElfChange = false;
 		bool stopAcqusitionOnElfChange = false;
 	} Settings;


### PR DESCRIPTION
https://github.com/klonyyy/STMViewer/commit/edbd032e0be50dd8f5462b05b548ef4c91d5112b makes use of system clock to update time axis limit:
- This allows for silky smooth scrolling - - removes stutter especially visible for low sampling rates - together with https://github.com/klonyyy/STMViewer/commit/605afa805711f925b806d826e028991da72eae36 closes #57 
- it also allows for straightforward usage of seconds (instead of samples) for the viewport width selection. Seconds are more natural and independant from varying sampling rate.

https://github.com/klonyyy/STMViewer/commit/e336bddda9670bc6fb90159208dec5f5263f0e10 enables axis limits alterations during acquisition. Mouse wheel can be used to zoom in and out. Closes #54 
The plot limits expansion at the beginning of the acquisition which makes zooming logic more robust.
