### PR TITLE
fix: don't share process for refreshing elf variables and importing variables

### DIFF
--- a/src/GdbParser/GdbParser.hpp
+++ b/src/GdbParser/GdbParser.hpp
@@ -40,10 +40,10 @@ class GdbParser
 	void changeCurrentGDBCommand(const std::string& command);
 
    private:
-	void parseVariableChunk(const std::string& chunk);
-	void checkVariableType(std::string& name);
-	Variable::Type checkType(const std::string& name, std::string* output);
-	std::optional<uint32_t> checkAddress(const std::string& name);
+	void parseVariableChunk(ProcessHandler& process, const std::string& chunk);
+	void checkVariableType(ProcessHandler& process, std::string& name);
+	Variable::Type checkType(ProcessHandler& process, const std::string& name, std::string* output);
+	std::optional<uint32_t> checkAddress(ProcessHandler& process, const std::string& name);
 
    private:
 	const char* defaultGDBCommand = "gdb";
@@ -52,7 +52,6 @@ class GdbParser
 	spdlog::logger* logger;
 	std::mutex mtx;
 	std::map<std::string, VariableData> parsedData;
-	ProcessHandler process;
 
 	std::unordered_map<std::string, Variable::Type> isTrivial = {
 		{"_Bool", Variable::Type::U8},


### PR DESCRIPTION
When one of the task ends, it closes the pipes leading to a crash in the other task. Use a different process instance to avoid the crash.

Note: I've found this crash on Linux.
I guess issues can happen on Windows too but maybe not a crash, just reads errors due to invalid file handle.

On `master` branch this is easy to trigger, just click import while it is still refreshing:
![image](https://github.com/user-attachments/assets/6a37a189-1e23-4d88-a459-bcd17807bd92)

On `devel`, it happens differently, for example like this:
- Add a variable
- Open `Import variables from elf` dialog
- It is now refreshing variables
- Before the end, close the dialog with the cross button
- Click on `Update variable addresses`

The crash occurs on fgets with `pipes.second` being nullptr:
https://github.com/klonyyy/MCUViewer/blob/36076ecc499c6e8a1e67c1e96c4159791341cc26/src/GdbParser/ProcessHandler.hpp#L58