### PR TITLE
feature: add support for esp-usb-jtag backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ set(PROJECT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/usb/EspUsbJtagTransport.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/jtag/EspJtagTap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/riscv/EspRiscvDm.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/xtensa/EspXtensaDm.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/EspProbeSession.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Plot/Plot.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Variable/Variable.cpp
@@ -219,6 +220,7 @@ target_include_directories(${EXECUTABLE} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/usb
     ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/jtag
     ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/riscv
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/xtensa
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Plot
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ScrollingBuffer
     ${CMAKE_CURRENT_SOURCE_DIR}/src/MovingAverage

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,18 @@ if(UNIX)
     set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
     include(${CMAKE_MODULE_PATH}/Findlibusb.cmake)
     find_package(libusb REQUIRED)
-    find_package(glfw3 REQUIRED)
+    find_package(glfw3 QUIET)
+    if(NOT glfw3_FOUND)
+        FetchContent_Declare(
+            glfw
+            GIT_REPOSITORY https://github.com/glfw/glfw.git
+            GIT_TAG 3.4)
+        set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
+        set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+        set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+        set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
+        FetchContent_MakeAvailable(glfw)
+    endif()
     set(STLINK_LINUX ${CMAKE_CURRENT_SOURCE_DIR}/third_party/stlink/lib/linux/libstlink.a)
     set(JLINK_LINUX ${CMAKE_CURRENT_SOURCE_DIR}/third_party/jlink/lib/linux/libjlinkarm.so.8)
     set(INSTALL_PATH /usr/local/MCUViewer)
@@ -121,6 +132,11 @@ set(PROJECT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Gui/GuiHelper.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/MemoryReader/StlinkDebugProbe.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/MemoryReader/JlinkDebugProbe.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/MemoryReader/EspUsbJtagDebugProbe.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/usb/EspUsbJtagTransport.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/jtag/EspJtagTap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/riscv/EspRiscvDm.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/EspProbeSession.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Plot/Plot.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Variable/Variable.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/MovingAverage/MovingAverage.cpp
@@ -158,6 +174,16 @@ set_source_files_properties(
     COMPILE_FLAGS "-w"
 )
 
+if(UNIX AND NOT APPLE)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(GTK3 gtk+-3.0)
+    endif()
+    if(NOT GTK3_FOUND)
+        set(NFD_PORTAL ON CACHE BOOL "Use xdg-desktop-portal for file dialogs" FORCE)
+    endif()
+endif()
+
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/nfd/)
 
 set(EXECUTABLE ${CMAKE_PROJECT_NAME})
@@ -189,6 +215,10 @@ target_compile_definitions(${EXECUTABLE}
 target_include_directories(${EXECUTABLE} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Gui
     ${CMAKE_CURRENT_SOURCE_DIR}/src/MemoryReader
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/usb
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/jtag
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/EspProbe/riscv
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Plot
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ScrollingBuffer
     ${CMAKE_CURRENT_SOURCE_DIR}/src/MovingAverage

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ MCUViewer (formerly STMViewer) is an open-source GUI debug tool for microcontrol
 1. Variable Viewer - used for viewing, logging, and manipulating variables data in realtime using debug interface (SWDIO / SWCLK / GND)
 2. Trace Viewer - used for graphically representing real-time SWO trace output (SWDIO / SWCLK / SWO / GND)
 
-The only piece of hardware required is an STLink or JLink programmer. 
+The only piece of hardware required is an STLink or JLink programmer. On Espressif RISC-V chips (ESP32-C3/C6/H2/P4), Variable Viewer can also use the **built-in USB-JTAG** interface — see [docs/ESP_USB_JTAG.md](./docs/ESP_USB_JTAG.md).
 
 ## Introduction
 
@@ -57,7 +57,9 @@ You can assign the external GPU to MCUViewer for improved performance.
 3. Click the `Import variables form *.elf`. Select variables and click `Import`. Note: the import feature is still in beta. If your variable is not automatically detected just click `Add variable` and input the name yourself. Please let me know if that happens by opening a new issue with *.elf file attached. 
 4. After adding all variables click `Update variable addresses`. The type and address of the variables you've added should change from "NOT FOUND!" to a valid address based on the *.elf file you've provided. Note: 64-bit variables (such as uint64_t and double) are not yet supported #13.
 5. Drag and drop the variable to the plot area.``
-6. Make sure the debug probe is connected and a proper type is selected (STLink/JLink). Download your executable to the microcontroller and press the `STOPPED` button. 
+6. Make sure the debug probe is connected and a proper type is selected (STLink/JLink/**ESP_USB_JTAG**). Download your executable to the microcontroller and press the `STOPPED` button. 
+
+For **ESP_USB_JTAG**, select the chip target (e.g. `esp32c6`), point GDB to `riscv32-esp-elf-gdb`, and close `idf.py monitor` before starting acquisition. See [docs/ESP_USB_JTAG.md](./docs/ESP_USB_JTAG.md).
 
 In case of any problems, please try the example/MCUViewer_test CubeIDE project and the corresponding MCUViewer_test.cfg project file. Please remember to build the project and update the elf file path in the `Options -> Acqusition` Settings. 
 
@@ -114,8 +116,10 @@ MCUViewer is build like any other CMake project:
 ### Linux:
 If you're a Linux user be sure to install: 
 1. libusb-1.0-0-dev
-2. libglfw3-dev
-3. libgtk-3-dev
+2. libglfw3-dev (optional — CMake fetches GLFW via FetchContent if missing)
+3. libgtk-3-dev (optional — without GTK, file dialogs use xdg-desktop-portal)
+
+For ESP USB-JTAG Variable Viewer you also need `riscv32-esp-elf-gdb` for ELF import.
 
 After a successful build, copy the `./third_party/stlink/chips` directory to where the binary is located. Otherwise the STlink will not detect your STM32 target. 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ MCUViewer (formerly STMViewer) is an open-source GUI debug tool for microcontrol
 1. Variable Viewer - used for viewing, logging, and manipulating variables data in realtime using debug interface (SWDIO / SWCLK / GND)
 2. Trace Viewer - used for graphically representing real-time SWO trace output (SWDIO / SWCLK / SWO / GND)
 
-The only piece of hardware required is an STLink or JLink programmer. On Espressif RISC-V chips (ESP32-C3/C6/H2/P4), Variable Viewer can also use the **built-in USB-JTAG** interface — see [docs/ESP_USB_JTAG.md](./docs/ESP_USB_JTAG.md).
+The only piece of hardware required is an STLink or JLink programmer. On Espressif chips with built-in USB-JTAG (ESP32-C3/C6/H2/P4, ESP32-S3), Variable Viewer can use that interface — see [docs/ESP_USB_JTAG.md](./docs/ESP_USB_JTAG.md).
 
 ## Introduction
 
@@ -59,7 +59,7 @@ You can assign the external GPU to MCUViewer for improved performance.
 5. Drag and drop the variable to the plot area.``
 6. Make sure the debug probe is connected and a proper type is selected (STLink/JLink/**ESP_USB_JTAG**). Download your executable to the microcontroller and press the `STOPPED` button. 
 
-For **ESP_USB_JTAG**, select the chip target (e.g. `esp32c6`), point GDB to `riscv32-esp-elf-gdb`, and close `idf.py monitor` before starting acquisition. See [docs/ESP_USB_JTAG.md](./docs/ESP_USB_JTAG.md).
+For **ESP_USB_JTAG**, select the chip target (e.g. `esp32c6` or `esp32s3`), point GDB to `riscv32-esp-elf-gdb` or `xtensa-esp32s3-elf-gdb`, and close `idf.py monitor` before starting acquisition. See [docs/ESP_USB_JTAG.md](./docs/ESP_USB_JTAG.md).
 
 In case of any problems, please try the example/MCUViewer_test CubeIDE project and the corresponding MCUViewer_test.cfg project file. Please remember to build the project and update the elf file path in the `Options -> Acqusition` Settings. 
 

--- a/docs/ESP_USB_JTAG.md
+++ b/docs/ESP_USB_JTAG.md
@@ -98,6 +98,31 @@ EspUsbJtagDebugProbe (IDebugProbe)
 
 Protocol and TAP sequencing are adapted from [openocd-esp32](https://github.com/espressif/openocd-esp32); MCUViewer does not shell out to OpenOCD.
 
+## Batch sampling (ESP_USB_JTAG)
+
+Variable Viewer calls `readMemoryBatch` when the probe supports it. On ESP, one sample tick uses a **single JTAG IR select** and **one SBA setup**, then reads every variable word in sequence. Addresses that share the same 32-bit aligned word are read once (useful for multi-axis structs in contiguous RAM).
+
+ST-Link and J-Link keep the legacy per-variable loop unless a probe overrides batch read.
+
+### Batch benchmark (optional)
+
+Compare single vs batch read latency with your ELF symbol addresses:
+
+```bash
+g++ -std=c++20 -O0 \
+  -Isrc/EspProbe -Isrc/EspProbe/usb -Isrc/EspProbe/jtag -Isrc/EspProbe/riscv \
+  tools/esp_probe_batch_bench.cpp \
+  src/EspProbe/usb/EspUsbJtagTransport.cpp \
+  src/EspProbe/jtag/EspJtagTap.cpp \
+  src/EspProbe/riscv/EspRiscvDm.cpp \
+  src/EspProbe/EspProbeSession.cpp \
+  -lusb-1.0 -o /tmp/esp_probe_batch_bench
+
+/tmp/esp_probe_batch_bench esp32c6 24000 500 0x4080xxxx 0x4080yyyy 0x4080zzzz
+```
+
+Arguments: `chip`, `speed_khz`, `rounds`, then one or more hex addresses (32-bit reads). Expect higher `speedup` as variable count grows.
+
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |

--- a/docs/ESP_USB_JTAG.md
+++ b/docs/ESP_USB_JTAG.md
@@ -1,6 +1,6 @@
 # ESP USB-JTAG (Variable Viewer)
 
-MCUViewer can sample global variables on Espressif RISC-V chips (ESP32-C3/C6/H2/P4) through the built-in USB-JTAG debug interface (`303a:1001`). No OpenOCD or external probe is required for Variable Viewer.
+MCUViewer can sample global variables on Espressif chips with built-in USB-JTAG (`303a:1001`): RISC-V (ESP32-C3/C6/H2/P4) and Xtensa ESP32-S3. No OpenOCD or external probe is required for Variable Viewer.
 
 Trace Viewer (SWO) is not supported on ESP32 — use ST-Link/J-Link targets for SWO.
 
@@ -12,17 +12,18 @@ Trace Viewer (SWO) is not supported on ESP32 — use ST-Link/J-Link targets for 
 | esp32c3  | `0x00005c25` | 1  |                    |
 | esp32h2  | `0x0000c825` | 1  |                    |
 | esp32p4  | `0x00012c25` | 2  | HP core on TAP 1   |
+| esp32s3  | `0x120034e5` | 2  | Xtensa dual-core, CPU0 TAP 0 |
 
-Xtensa chips (ESP32, ESP32-S2/S3) are not implemented yet.
+RISC-V targets read RAM while the CPU runs (System Bus Access). **esp32s3** uses Xtensa `LDDR32.P` and briefly halts the core once per sample batch, then resumes — expect lower max sampling rate than C6 on the same variables.
 
 ## Requirements
 
 ### Linux
 
 - `libusb-1.0-0-dev`
-- `riscv32-esp-elf-gdb` (or compatible GDB 12.1+) for ELF parsing only
+- `riscv32-esp-elf-gdb` or `xtensa-esp32s3-elf-gdb` (GDB 12.1+) for ELF parsing only — match your chip
 - User in the `plugdev` group (or udev rules for `303a:1001`)
-- Firmware running on the target (MCUViewer reads RAM while the CPU runs)
+- Firmware running on the target (RISC-V: non-intrusive RAM read; S3: brief halt per batch)
 
 ### Host conflicts
 
@@ -42,7 +43,7 @@ After stopping acquisition, MCUViewer resumes the core and clears the debug modu
    - Chip target: match your SoC (e.g. `esp32c6`)
    - JTAG speed: `24000` kHz (default)
    - ELF: path to your `build/<project>.elf`
-   - GDB: `riscv32-esp-elf-gdb`
+   - GDB: `riscv32-esp-elf-gdb` (RISC-V) or `xtensa-esp32s3-elf-gdb` (S3)
 3. Import variables by symbol name and **Update variable addresses**.
 4. Drag variables to a plot and press **START**.
 
@@ -93,7 +94,8 @@ EspUsbJtagDebugProbe (IDebugProbe)
   └── EspProbeSession
         ├── EspUsbJtagTransport   USB bulk protocol (OpenOCD esp_usb_jtag.c)
         ├── EspJtagTap            IR/DR scans
-        └── EspRiscvDm            DMI + System Bus Access (memory read/write)
+        └── EspRiscvDm            DMI + System Bus Access (RISC-V memory)
+        └── EspXtensaDm           NAR + LDDR32.P (Xtensa memory, halt/resume per batch)
 ```
 
 Protocol and TAP sequencing are adapted from [openocd-esp32](https://github.com/espressif/openocd-esp32); MCUViewer does not shell out to OpenOCD.
@@ -128,7 +130,7 @@ Arguments: `chip`, `speed_khz`, `rounds`, then one or more hex addresses (32-bit
 | Symptom | Likely cause | Fix |
 |---------|----------------|-----|
 | `libusb_claim_interface failed` | Monitor/OpenOCD holding USB | Close other tools |
-| `RISC-V debug module init failed` | Wrong chip profile or USB busy | Match chip target; replug USB |
+| `RISC-V debug module init failed` / `Xtensa debug module init failed` | Wrong chip profile or USB busy | Match chip target; replug USB |
 | Bootloader OK, no app logs after MCUViewer | Core left halted (old builds) | Replug USB or `openocd … -c "init; reset run; shutdown"` |
 | `/dev/ttyACM0` missing | Kernel driver detached from CDC | Replug USB; use current build with graceful shutdown |
 | Variables `NOT FOUND` | Wrong ELF or non-global vars | Rebuild debug ELF; globals only |

--- a/docs/ESP_USB_JTAG.md
+++ b/docs/ESP_USB_JTAG.md
@@ -1,0 +1,114 @@
+# ESP USB-JTAG (Variable Viewer)
+
+MCUViewer can sample global variables on Espressif RISC-V chips (ESP32-C3/C6/H2/P4) through the built-in USB-JTAG debug interface (`303a:1001`). No OpenOCD or external probe is required for Variable Viewer.
+
+Trace Viewer (SWO) is not supported on ESP32 — use ST-Link/J-Link targets for SWO.
+
+## Supported targets
+
+| Chip     | IDCODE     | TAPs | Notes              |
+|----------|------------|------|--------------------|
+| esp32c6  | `0x0000dc25` | 1  | Default in GUI     |
+| esp32c3  | `0x00005c25` | 1  |                    |
+| esp32h2  | `0x0000c825` | 1  |                    |
+| esp32p4  | `0x00012c25` | 2  | HP core on TAP 1   |
+
+Xtensa chips (ESP32, ESP32-S2/S3) are not implemented yet.
+
+## Requirements
+
+### Linux
+
+- `libusb-1.0-0-dev`
+- `riscv32-esp-elf-gdb` (or compatible GDB 12.1+) for ELF parsing only
+- User in the `plugdev` group (or udev rules for `303a:1001`)
+- Firmware running on the target (MCUViewer reads RAM while the CPU runs)
+
+### Host conflicts
+
+Only one program may own the USB-JTAG interface at a time. Close before starting MCUViewer:
+
+- `idf.py monitor`
+- OpenOCD
+- Another MCUViewer instance
+
+After stopping acquisition, MCUViewer resumes the core and clears the debug module so `idf.py monitor` works again. If the serial port (`/dev/ttyACM0`) is missing, unplug and replug USB.
+
+## Quick start
+
+1. Build and flash your ESP-IDF project in **debug** mode (`idf.py build flash`).
+2. **Options → Acquisition**
+   - Probe: **ESP_USB_JTAG**
+   - Chip target: match your SoC (e.g. `esp32c6`)
+   - JTAG speed: `24000` kHz (default)
+   - ELF: path to your `build/<project>.elf`
+   - GDB: `riscv32-esp-elf-gdb`
+3. Import variables by symbol name and **Update variable addresses**.
+4. Drag variables to a plot and press **START**.
+
+Close `idf.py monitor` before starting acquisition.
+
+## Firmware constraints
+
+Variable Viewer reads RAM directly via the debug bus. Variables must meet the same rules as for ST-Link/J-Link:
+
+- **Global** scope (file scope or `static` globals) — stack locals and heap objects are not stable
+- Address fixed for the lifetime of the firmware image (rebuild + update ELF if layout changes)
+- Debug symbols present in the ELF (`-g`, no strip)
+
+To find a symbol address from your build:
+
+```bash
+riscv32-esp-elf-nm build/<project>.elf | grep my_variable
+# or
+riscv32-esp-elf-gdb build/<project>.elf -ex "print &my_variable" -ex quit
+```
+
+## Hardware smoke test (optional)
+
+Validates USB-JTAG + DMI + memory read without the GUI. Pass a 32-bit address from your ELF map:
+
+```bash
+cd build
+cmake .. && cmake --build . -j$(nproc)   # if not built yet
+
+g++ -std=c++20 -O0 \
+  -Isrc/EspProbe -Isrc/EspProbe/usb -Isrc/EspProbe/jtag -Isrc/EspProbe/riscv \
+  tools/esp_probe_smoke.cpp \
+  src/EspProbe/usb/EspUsbJtagTransport.cpp \
+  src/EspProbe/jtag/EspJtagTap.cpp \
+  src/EspProbe/riscv/EspRiscvDm.cpp \
+  src/EspProbe/EspProbeSession.cpp \
+  -lusb-1.0 -o /tmp/esp_probe_smoke
+
+/tmp/esp_probe_smoke esp32c6 24000 0x4080xxxx
+```
+
+Arguments: `[chip] [speed_khz] [address_hex]`. Defaults: `esp32c6`, `24000`, address required.
+
+## Architecture
+
+```
+EspUsbJtagDebugProbe (IDebugProbe)
+  └── EspProbeSession
+        ├── EspUsbJtagTransport   USB bulk protocol (OpenOCD esp_usb_jtag.c)
+        ├── EspJtagTap            IR/DR scans
+        └── EspRiscvDm            DMI + System Bus Access (memory read/write)
+```
+
+Protocol and TAP sequencing are adapted from [openocd-esp32](https://github.com/espressif/openocd-esp32); MCUViewer does not shell out to OpenOCD.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|----------------|-----|
+| `libusb_claim_interface failed` | Monitor/OpenOCD holding USB | Close other tools |
+| `RISC-V debug module init failed` | Wrong chip profile or USB busy | Match chip target; replug USB |
+| Bootloader OK, no app logs after MCUViewer | Core left halted (old builds) | Replug USB or `openocd … -c "init; reset run; shutdown"` |
+| `/dev/ttyACM0` missing | Kernel driver detached from CDC | Replug USB; use current build with graceful shutdown |
+| Variables `NOT FOUND` | Wrong ELF or non-global vars | Rebuild debug ELF; globals only |
+| Flat line at zero | Acquisition stopped or wrong address | START acquisition; update addresses |
+
+## Upstream note
+
+This backend targets the open-source MCUViewer 1.1.0 tree. Windows support for ESP USB-JTAG is not wired in CMake yet (Linux-only path).

--- a/src/DataHandler/ViewerDataHandler.cpp
+++ b/src/DataHandler/ViewerDataHandler.cpp
@@ -119,6 +119,8 @@ void ViewerDataHandler::dataHandler()
 
 			else if (period > ((1.0 / settings.sampleFrequencyHz) * timer))
 			{
+				createSampleList();
+
 				std::unordered_map<uint32_t, double> rawValues;
 
 				if (debugProbe->supportsBatchRead())

--- a/src/DataHandler/ViewerDataHandler.cpp
+++ b/src/DataHandler/ViewerDataHandler.cpp
@@ -121,15 +121,32 @@ void ViewerDataHandler::dataHandler()
 			{
 				std::unordered_map<uint32_t, double> rawValues;
 
-				/* sample by address */
-				for (auto& [address, size] : sampleList)
+				if (debugProbe->supportsBatchRead())
 				{
-					uint32_t value = 0;
-					if (debugProbe->readMemory(address, (uint8_t*)&value, size))
-						rawValues[address] = value;
-					else
+					std::unordered_map<uint32_t, uint32_t> batch;
+					if (!debugProbe->readMemoryBatch(sampleList, batch))
 						setState(State::STOP);
+					else
+					{
+						for (const auto& [address, raw] : batch)
+							rawValues[address] = raw;
+					}
 				}
+				else
+				{
+					for (auto& [address, size] : sampleList)
+					{
+						uint32_t value = 0;
+						if (debugProbe->readMemory(address, (uint8_t*)&value, size))
+							rawValues[address] = value;
+						else
+							setState(State::STOP);
+					}
+				}
+
+				if (viewerState != State::RUN)
+					continue;
+
 				double timestamp = std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::steady_clock::now() - start).count();
 				updateVariables(timestamp, rawValues);
 

--- a/src/EspProbe/EspProbeSession.cpp
+++ b/src/EspProbe/EspProbeSession.cpp
@@ -9,11 +9,6 @@ bool EspProbeSession::connect(const std::string& serial, const std::string& chip
 	last_error_.clear();
 
 	profile_ = find_chip_profile(chip_name.c_str());
-	if (!profile_->is_riscv)
-	{
-		last_error_ = "Chip architecture not supported yet (Xtensa pending)";
-		return false;
-	}
 
 	transport_ = std::make_unique<EspUsbJtagTransport>();
 	if (!transport_->open(serial))
@@ -30,15 +25,30 @@ bool EspProbeSession::connect(const std::string& serial, const std::string& chip
 	}
 
 	tap_ = std::make_unique<EspJtagTap>(*transport_);
-	dm_ = std::make_unique<EspRiscvDm>(*tap_, *profile_);
 
-	if (!dm_->init())
+	if (profile_->is_riscv)
 	{
-		last_error_ = dm_->lastError();
-		if (last_error_.empty())
-			last_error_ = "RISC-V debug module init failed";
-		disconnect();
-		return false;
+		riscv_dm_ = std::make_unique<EspRiscvDm>(*tap_, *profile_);
+		if (!riscv_dm_->init())
+		{
+			last_error_ = riscv_dm_->lastError();
+			if (last_error_.empty())
+				last_error_ = "RISC-V debug module init failed";
+			disconnect();
+			return false;
+		}
+	}
+	else
+	{
+		xtensa_dm_ = std::make_unique<EspXtensaDm>(*tap_, *profile_);
+		if (!xtensa_dm_->init())
+		{
+			last_error_ = xtensa_dm_->lastError();
+			if (last_error_.empty())
+				last_error_ = "Xtensa debug module init failed";
+			disconnect();
+			return false;
+		}
 	}
 
 	connected_ = true;
@@ -47,9 +57,12 @@ bool EspProbeSession::connect(const std::string& serial, const std::string& chip
 
 void EspProbeSession::disconnect()
 {
-	if (dm_)
-		dm_->shutdown();
-	dm_.reset();
+	if (riscv_dm_)
+		riscv_dm_->shutdown();
+	if (xtensa_dm_)
+		xtensa_dm_->shutdown();
+	riscv_dm_.reset();
+	xtensa_dm_.reset();
 	tap_.reset();
 	if (transport_)
 		transport_->close();
@@ -60,49 +73,106 @@ void EspProbeSession::disconnect()
 bool EspProbeSession::readMemoryBatch(const std::vector<std::pair<uint32_t, uint8_t>>& entries,
 	std::unordered_map<uint32_t, uint32_t>& values)
 {
-	if (!connected_ || !dm_)
+	if (!connected_)
 	{
 		last_error_ = "Not connected";
 		return false;
 	}
-	if (!dm_->readMemoryBatch(entries, values))
+
+	if (riscv_dm_)
 	{
-		last_error_ = dm_->lastError();
-		if (last_error_.empty())
-			last_error_ = "Memory batch read failed";
-		return false;
+		if (!riscv_dm_->readMemoryBatch(entries, values))
+		{
+			last_error_ = riscv_dm_->lastError();
+			if (last_error_.empty())
+				last_error_ = "Memory batch read failed";
+			return false;
+		}
+		return true;
 	}
-	return true;
+
+	if (xtensa_dm_)
+	{
+		if (!xtensa_dm_->readMemoryBatch(entries, values))
+		{
+			last_error_ = xtensa_dm_->lastError();
+			if (last_error_.empty())
+				last_error_ = "Memory batch read failed";
+			return false;
+		}
+		return true;
+	}
+
+	last_error_ = "Not connected";
+	return false;
 }
 
 bool EspProbeSession::readMemory(uint32_t address, uint8_t* buf, uint32_t size)
 {
-	if (!connected_ || !dm_)
+	if (!connected_)
 	{
 		last_error_ = "Not connected";
 		return false;
 	}
-	if (!dm_->readMemory(address, buf, size))
+
+	if (riscv_dm_)
 	{
-		last_error_ = "Memory read failed";
-		return false;
+		if (!riscv_dm_->readMemory(address, buf, size))
+		{
+			last_error_ = "Memory read failed";
+			return false;
+		}
+		return true;
 	}
-	return true;
+
+	if (xtensa_dm_)
+	{
+		if (!xtensa_dm_->readMemory(address, buf, size))
+		{
+			last_error_ = xtensa_dm_->lastError();
+			if (last_error_.empty())
+				last_error_ = "Memory read failed";
+			return false;
+		}
+		return true;
+	}
+
+	last_error_ = "Not connected";
+	return false;
 }
 
 bool EspProbeSession::writeMemory(uint32_t address, const uint8_t* buf, uint32_t size)
 {
-	if (!connected_ || !dm_)
+	if (!connected_)
 	{
 		last_error_ = "Not connected";
 		return false;
 	}
-	if (!dm_->writeMemory(address, buf, size))
+
+	if (riscv_dm_)
 	{
-		last_error_ = "Memory write failed";
-		return false;
+		if (!riscv_dm_->writeMemory(address, buf, size))
+		{
+			last_error_ = "Memory write failed";
+			return false;
+		}
+		return true;
 	}
-	return true;
+
+	if (xtensa_dm_)
+	{
+		if (!xtensa_dm_->writeMemory(address, buf, size))
+		{
+			last_error_ = xtensa_dm_->lastError();
+			if (last_error_.empty())
+				last_error_ = "Memory write failed";
+			return false;
+		}
+		return true;
+	}
+
+	last_error_ = "Not connected";
+	return false;
 }
 
 }  // namespace esp_probe

--- a/src/EspProbe/EspProbeSession.cpp
+++ b/src/EspProbe/EspProbeSession.cpp
@@ -57,6 +57,24 @@ void EspProbeSession::disconnect()
 	connected_ = false;
 }
 
+bool EspProbeSession::readMemoryBatch(const std::vector<std::pair<uint32_t, uint8_t>>& entries,
+	std::unordered_map<uint32_t, uint32_t>& values)
+{
+	if (!connected_ || !dm_)
+	{
+		last_error_ = "Not connected";
+		return false;
+	}
+	if (!dm_->readMemoryBatch(entries, values))
+	{
+		last_error_ = dm_->lastError();
+		if (last_error_.empty())
+			last_error_ = "Memory batch read failed";
+		return false;
+	}
+	return true;
+}
+
 bool EspProbeSession::readMemory(uint32_t address, uint8_t* buf, uint32_t size)
 {
 	if (!connected_ || !dm_)

--- a/src/EspProbe/EspProbeSession.cpp
+++ b/src/EspProbe/EspProbeSession.cpp
@@ -1,0 +1,90 @@
+#include "EspProbeSession.hpp"
+
+namespace esp_probe
+{
+
+bool EspProbeSession::connect(const std::string& serial, const std::string& chip_name, uint32_t speed_khz)
+{
+	disconnect();
+	last_error_.clear();
+
+	profile_ = find_chip_profile(chip_name.c_str());
+	if (!profile_->is_riscv)
+	{
+		last_error_ = "Chip architecture not supported yet (Xtensa pending)";
+		return false;
+	}
+
+	transport_ = std::make_unique<EspUsbJtagTransport>();
+	if (!transport_->open(serial))
+	{
+		last_error_ = transport_->lastError();
+		if (last_error_.empty())
+			last_error_ = "ESP USB-JTAG device not found";
+		return false;
+	}
+	if (!transport_->setSpeedKhz(speed_khz))
+	{
+		last_error_ = "Failed to set JTAG speed";
+		return false;
+	}
+
+	tap_ = std::make_unique<EspJtagTap>(*transport_);
+	dm_ = std::make_unique<EspRiscvDm>(*tap_, *profile_);
+
+	if (!dm_->init())
+	{
+		last_error_ = dm_->lastError();
+		if (last_error_.empty())
+			last_error_ = "RISC-V debug module init failed";
+		disconnect();
+		return false;
+	}
+
+	connected_ = true;
+	return true;
+}
+
+void EspProbeSession::disconnect()
+{
+	if (dm_)
+		dm_->shutdown();
+	dm_.reset();
+	tap_.reset();
+	if (transport_)
+		transport_->close();
+	transport_.reset();
+	connected_ = false;
+}
+
+bool EspProbeSession::readMemory(uint32_t address, uint8_t* buf, uint32_t size)
+{
+	if (!connected_ || !dm_)
+	{
+		last_error_ = "Not connected";
+		return false;
+	}
+	if (!dm_->readMemory(address, buf, size))
+	{
+		last_error_ = "Memory read failed";
+		return false;
+	}
+	return true;
+}
+
+bool EspProbeSession::writeMemory(uint32_t address, const uint8_t* buf, uint32_t size)
+{
+	if (!connected_ || !dm_)
+	{
+		last_error_ = "Not connected";
+		return false;
+	}
+	if (!dm_->writeMemory(address, buf, size))
+	{
+		last_error_ = "Memory write failed";
+		return false;
+	}
+	return true;
+}
+
+}  // namespace esp_probe

--- a/src/EspProbe/EspProbeSession.hpp
+++ b/src/EspProbe/EspProbeSession.hpp
@@ -1,0 +1,38 @@
+#ifndef ESP_PROBE_SESSION_HPP
+#define ESP_PROBE_SESSION_HPP
+
+#include <memory>
+#include <string>
+
+#include "esp_riscv_regs.hpp"
+#include "jtag/EspJtagTap.hpp"
+#include "riscv/EspRiscvDm.hpp"
+#include "usb/EspUsbJtagTransport.hpp"
+
+namespace esp_probe
+{
+
+class EspProbeSession
+{
+   public:
+	bool connect(const std::string& serial, const std::string& chip_name, uint32_t speed_khz);
+	void disconnect();
+	bool isConnected() const { return connected_; }
+
+	bool readMemory(uint32_t address, uint8_t* buf, uint32_t size);
+	bool writeMemory(uint32_t address, const uint8_t* buf, uint32_t size);
+
+	const std::string& lastError() const { return last_error_; }
+
+   private:
+	std::unique_ptr<EspUsbJtagTransport> transport_;
+	std::unique_ptr<EspJtagTap> tap_;
+	std::unique_ptr<EspRiscvDm> dm_;
+	const EspChipProfile* profile_ = nullptr;
+	bool connected_ = false;
+	std::string last_error_;
+};
+
+}  // namespace esp_probe
+
+#endif

--- a/src/EspProbe/EspProbeSession.hpp
+++ b/src/EspProbe/EspProbeSession.hpp
@@ -11,6 +11,7 @@
 #include "jtag/EspJtagTap.hpp"
 #include "riscv/EspRiscvDm.hpp"
 #include "usb/EspUsbJtagTransport.hpp"
+#include "xtensa/EspXtensaDm.hpp"
 
 namespace esp_probe
 {
@@ -32,7 +33,8 @@ class EspProbeSession
    private:
 	std::unique_ptr<EspUsbJtagTransport> transport_;
 	std::unique_ptr<EspJtagTap> tap_;
-	std::unique_ptr<EspRiscvDm> dm_;
+	std::unique_ptr<EspRiscvDm> riscv_dm_;
+	std::unique_ptr<EspXtensaDm> xtensa_dm_;
 	const EspChipProfile* profile_ = nullptr;
 	bool connected_ = false;
 	std::string last_error_;

--- a/src/EspProbe/EspProbeSession.hpp
+++ b/src/EspProbe/EspProbeSession.hpp
@@ -3,6 +3,9 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "esp_riscv_regs.hpp"
 #include "jtag/EspJtagTap.hpp"
@@ -20,6 +23,8 @@ class EspProbeSession
 	bool isConnected() const { return connected_; }
 
 	bool readMemory(uint32_t address, uint8_t* buf, uint32_t size);
+	bool readMemoryBatch(const std::vector<std::pair<uint32_t, uint8_t>>& entries,
+		std::unordered_map<uint32_t, uint32_t>& values);
 	bool writeMemory(uint32_t address, const uint8_t* buf, uint32_t size);
 
 	const std::string& lastError() const { return last_error_; }

--- a/src/EspProbe/esp_bit_utils.hpp
+++ b/src/EspProbe/esp_bit_utils.hpp
@@ -1,0 +1,45 @@
+#ifndef ESP_BIT_UTILS_HPP
+#define ESP_BIT_UTILS_HPP
+
+#include <cstdint>
+#include <cstring>
+
+namespace esp_probe
+{
+
+inline void buf_set_u32(uint8_t* buffer, unsigned offset, unsigned width, uint32_t value)
+{
+	for (unsigned i = 0; i < width; i++)
+	{
+		if ((value >> i) & 1)
+			buffer[(offset + i) / 8] |= static_cast<uint8_t>(1u << ((offset + i) % 8));
+		else
+			buffer[(offset + i) / 8] &= static_cast<uint8_t>(~(1u << ((offset + i) % 8)));
+	}
+}
+
+inline uint32_t buf_get_u32(const uint8_t* buffer, unsigned offset, unsigned width)
+{
+	uint32_t value = 0;
+	for (unsigned i = 0; i < width; i++)
+	{
+		if (buffer[(offset + i) / 8] & (1u << ((offset + i) % 8)))
+			value |= 1u << i;
+	}
+	return value;
+}
+
+inline uint32_t set_field_u32(uint32_t reg, uint32_t mask, uint32_t value)
+{
+	const uint32_t shift = static_cast<uint32_t>(__builtin_ctz(mask));
+	return (reg & ~mask) | ((value << shift) & mask);
+}
+
+inline uint32_t get_field_u32(uint32_t reg, uint32_t mask)
+{
+	return reg & mask;
+}
+
+}  // namespace esp_probe
+
+#endif

--- a/src/EspProbe/esp_riscv_regs.hpp
+++ b/src/EspProbe/esp_riscv_regs.hpp
@@ -69,6 +69,7 @@ inline const EspChipProfile* find_chip_profile(const char* name)
 		{"esp32p4", 0x00012c25, 2, 5, 1, true},
 		{"esp32c3", 0x00005c25, 1, 5, 0, true},
 		{"esp32h2", 0x0000c825, 1, 5, 0, true},
+		{"esp32s3", 0x120034e5, 2, 5, 0, false},
 	};
 	for (const auto& p : profiles)
 	{

--- a/src/EspProbe/esp_riscv_regs.hpp
+++ b/src/EspProbe/esp_riscv_regs.hpp
@@ -1,0 +1,83 @@
+#ifndef ESP_RISCV_REGS_HPP
+#define ESP_RISCV_REGS_HPP
+
+#include <cstdint>
+#include <string_view>
+
+namespace esp_probe
+{
+
+constexpr uint8_t kIrBypass = 0x1f;
+constexpr uint8_t kIrIdcode = 0x01;
+constexpr uint8_t kIrDtmControl = 0x10;
+constexpr uint8_t kIrDbus = 0x11;
+
+constexpr uint32_t kDmiOpNop = 0;
+constexpr uint32_t kDmiOpRead = 1;
+constexpr uint32_t kDmiOpWrite = 2;
+
+constexpr uint32_t kDmiStatusSuccess = 0;
+constexpr uint32_t kDmiStatusFailed = 2;
+constexpr uint32_t kDmiStatusBusy = 3;
+
+constexpr uint32_t kDmDmControl = 0x10;
+constexpr uint32_t kDmDmStatus = 0x11;
+constexpr uint32_t kDmSbCs = 0x38;
+constexpr uint32_t kDmSbAddress0 = 0x39;
+constexpr uint32_t kDmSbData0 = 0x3c;
+
+constexpr uint32_t kDmControlDmActive = 1u;
+constexpr uint32_t kDmControlHaltReq = 0x80000000u;
+constexpr uint32_t kDmControlResumeReq = 0x40000000u;
+constexpr uint32_t kDmControlHartSelLo = 0x3ff0000u;
+constexpr uint32_t kDmControlHartSelHi = 0xffc0u;
+constexpr uint32_t kDmControlHaSel = 0x4000000u;
+
+constexpr uint32_t kDmSbCsSbAccess = 0xe0000u;
+constexpr uint32_t kDmSbCsSbReadOnAddr = 1u << 20;
+constexpr uint32_t kDmSbCsSbSingleRead = 1u << 20;
+
+constexpr uint32_t kDmSbCsSbVersion = 0xe0000000u;
+constexpr uint32_t kDmSbCsSbVersion10 = 1u;
+
+constexpr uint32_t kDtmDtmcsVersion = 0xfu;
+constexpr uint32_t kDtmDtmcsAbits = 0x3f0u;
+constexpr uint32_t kDtmDtmcsIdle = 0x7000u;
+constexpr uint32_t kDtmDtmcsVersion10 = 1u;
+
+constexpr unsigned kDmiOpOffset = 0;
+constexpr unsigned kDmiDataOffset = 2;
+constexpr unsigned kDmiAddressOffset = 34;
+
+constexpr uint32_t kDtmDmiOpLength = 2;
+constexpr uint32_t kDtmDmiDataLength = 32;
+
+struct EspChipProfile
+{
+	const char* name;
+	uint32_t idcode;
+	uint8_t tap_count;
+	uint8_t ir_len;
+	uint8_t cpu_tap_index;
+	bool is_riscv;
+};
+
+inline const EspChipProfile* find_chip_profile(const char* name)
+{
+	static const EspChipProfile profiles[] = {
+		{"esp32c6", 0x0000dc25, 1, 5, 0, true},
+		{"esp32p4", 0x00012c25, 2, 5, 1, true},
+		{"esp32c3", 0x00005c25, 1, 5, 0, true},
+		{"esp32h2", 0x0000c825, 1, 5, 0, true},
+	};
+	for (const auto& p : profiles)
+	{
+		if (name && p.name && std::string_view(name) == p.name)
+			return &p;
+	}
+	return &profiles[0];
+}
+
+}  // namespace esp_probe
+
+#endif

--- a/src/EspProbe/jtag/EspJtagTap.cpp
+++ b/src/EspProbe/jtag/EspJtagTap.cpp
@@ -1,0 +1,152 @@
+#include "EspJtagTap.hpp"
+
+#include <cstring>
+
+#include "EspUsbJtagTransport.hpp"
+
+namespace esp_probe
+{
+
+EspJtagTap::EspJtagTap(EspUsbJtagTransport& transport) : transport_(transport) {}
+
+void EspJtagTap::clockBit(int tms, int tdi, bool capture, int* tdo_out)
+{
+	transport_.clk(tms, tdi, capture);
+	if (capture && tdo_out)
+	{
+		if (transport_.flush() != 0)
+			*tdo_out = 0;
+		else
+			*tdo_out = transport_.readTdoBit();
+	}
+}
+
+void EspJtagTap::reset()
+{
+	transport_.tapReset();
+	state_ = State::TestLogicReset;
+}
+
+void EspJtagTap::runIdle(unsigned cycles)
+{
+	moveToRunIdle();
+	for (unsigned i = 0; i < cycles; ++i)
+		transport_.clk(0, 0, false);
+	transport_.flush();
+	state_ = State::RunIdle;
+}
+
+void EspJtagTap::moveToRunIdle()
+{
+	if (state_ == State::RunIdle)
+		return;
+	if (state_ == State::TestLogicReset)
+		transport_.clk(0, 0, false);
+	else
+	{
+		transport_.clk(1, 0, false);
+		transport_.clk(1, 0, false);
+		transport_.clk(0, 0, false);
+	}
+	transport_.flush();
+	state_ = State::RunIdle;
+}
+
+void EspJtagTap::moveToShiftIr()
+{
+	moveToRunIdle();
+	transport_.clk(1, 0, false);
+	transport_.clk(1, 0, false);
+	transport_.clk(0, 0, false);
+	transport_.clk(0, 0, false);
+}
+
+void EspJtagTap::moveToCaptureDr()
+{
+	moveToRunIdle();
+	transport_.clk(1, 0, false);
+	transport_.clk(0, 0, false);
+}
+
+void EspJtagTap::moveToShiftDr()
+{
+	moveToRunIdle();
+	transport_.clk(1, 0, false);
+	transport_.clk(0, 0, false);
+	transport_.clk(0, 0, false);
+}
+
+void EspJtagTap::exitShiftToRunIdle()
+{
+	transport_.clk(1, 0, false);
+	transport_.clk(0, 0, false);
+	transport_.flush();
+	state_ = State::RunIdle;
+}
+
+bool EspJtagTap::irScan(const std::vector<uint8_t>& ir_per_tap, unsigned ir_len)
+{
+	if (ir_len == 0 || ir_per_tap.empty())
+		return false;
+
+	moveToShiftIr();
+	for (unsigned t = 0; t < ir_per_tap.size(); ++t)
+	{
+		const uint8_t ir = ir_per_tap[t];
+		for (unsigned b = 0; b < ir_len; ++b)
+		{
+			const bool last = (t == ir_per_tap.size() - 1) && (b == ir_len - 1);
+			const int tdi = (ir >> b) & 1;
+			transport_.clk(last ? 1 : 0, tdi, false);
+		}
+	}
+
+	transport_.flush();
+	exitShiftToRunIdle();
+	return true;
+}
+
+bool EspJtagTap::drScan(unsigned dr_bits, const uint8_t* out_bits, uint8_t* in_bits)
+{
+	if (dr_bits == 0)
+		return false;
+
+	if (in_bits)
+		std::memset(in_bits, 0, (dr_bits + 7) / 8);
+
+	if (dr_bits == 32)
+		moveToCaptureDr();
+	else
+		moveToShiftDr();
+
+	const bool align_tdo = in_bits != nullptr && dr_bits == 32;
+	const unsigned capture_bits = align_tdo ? dr_bits + 1 : dr_bits;
+	for (unsigned i = 0; i < capture_bits; ++i)
+	{
+		const bool last = (i == capture_bits - 1);
+		const int tdi = (out_bits && i < dr_bits) ? ((out_bits[i / 8] >> (i % 8)) & 1) : 0;
+		transport_.clk(last ? 1 : 0, tdi, in_bits != nullptr);
+	}
+
+	if (transport_.flush() != 0)
+		return false;
+
+	if (in_bits)
+	{
+		if (align_tdo && transport_.readTdoBit() < 0)
+			return false;
+		for (unsigned i = 0; i < dr_bits; ++i)
+		{
+			const int tdo = transport_.readTdoBit();
+			if (tdo < 0)
+				return false;
+			if (tdo > 0)
+				in_bits[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+		}
+	}
+
+	exitShiftToRunIdle();
+	return true;
+}
+
+}  // namespace esp_probe

--- a/src/EspProbe/jtag/EspJtagTap.hpp
+++ b/src/EspProbe/jtag/EspJtagTap.hpp
@@ -1,0 +1,43 @@
+#ifndef ESP_JTAG_TAP_HPP
+#define ESP_JTAG_TAP_HPP
+
+#include <cstdint>
+#include <vector>
+
+namespace esp_probe
+{
+
+class EspUsbJtagTransport;
+
+class EspJtagTap
+{
+   public:
+	explicit EspJtagTap(EspUsbJtagTransport& transport);
+
+	void reset();
+	void runIdle(unsigned cycles);
+	bool irScan(const std::vector<uint8_t>& ir_per_tap, unsigned ir_len);
+	bool drScan(unsigned dr_bits, const uint8_t* out_bits, uint8_t* in_bits);
+
+   private:
+	enum class State
+	{
+		TestLogicReset,
+		RunIdle,
+		Other,
+	};
+
+	void moveToRunIdle();
+	void moveToShiftIr();
+	void moveToCaptureDr();
+	void moveToShiftDr();
+	void exitShiftToRunIdle();
+	void clockBit(int tms, int tdi, bool capture, int* tdo_out = nullptr);
+
+	EspUsbJtagTransport& transport_;
+	State state_ = State::TestLogicReset;
+};
+
+}  // namespace esp_probe
+
+#endif

--- a/src/EspProbe/riscv/EspRiscvDm.cpp
+++ b/src/EspProbe/riscv/EspRiscvDm.cpp
@@ -68,17 +68,6 @@ uint32_t packRawValue(uint32_t address, uint8_t size, uint32_t word)
 
 EspRiscvDm::EspRiscvDm(EspJtagTap& tap, const EspChipProfile& profile) : tap_(tap), profile_(profile) {}
 
-bool EspRiscvDm::beginDmiBatch()
-{
-	batch_active_ = selectDbusIr();
-	return batch_active_;
-}
-
-void EspRiscvDm::endDmiBatch()
-{
-	batch_active_ = false;
-}
-
 bool EspRiscvDm::selectDbusIr()
 {
 	std::vector<uint8_t> ir;
@@ -361,23 +350,7 @@ bool EspRiscvDm::readMemoryBatch(const std::vector<MemoryEntry>& entries, std::u
 	if (entries.empty())
 		return true;
 
-	if (!beginDmiBatch())
-	{
-		last_error_ = "DMI batch start failed";
-		return false;
-	}
-
-	bool ok = false;
 	std::unordered_map<uint32_t, uint32_t> words;
-
-	if (sb_sba_v1_)
-	{
-		uint32_t sbcs_write = set_field_u32(0, kDmSbCsSbReadOnAddr, 1u);
-		sbcs_write = set_field_u32(sbcs_write, kDmSbCsSbAccess, 2u);
-		if (!dmiWrite(kDmSbCs, sbcs_write))
-			goto done;
-	}
-
 	for (const auto& [address, size] : entries)
 	{
 		(void)size;
@@ -385,33 +358,13 @@ bool EspRiscvDm::readMemoryBatch(const std::vector<MemoryEntry>& entries, std::u
 		if (words.contains(aligned))
 			continue;
 
-		if (!sb_sba_v1_)
-		{
-			if (!dmiWrite(kDmSbAddress0, aligned))
-				goto done;
-			uint32_t sbcs = set_field_u32(0, kDmSbCsSbAccess, 2u);
-			sbcs = set_field_u32(sbcs, kDmSbCsSbSingleRead, 1u);
-			if (!dmiWrite(kDmSbCs, sbcs))
-				goto done;
-		}
-		else if (!dmiWrite(kDmSbAddress0, aligned))
-		{
-			goto done;
-		}
-
 		uint32_t word = 0;
-		if (!dmiRead(kDmSbData0, &word))
-			goto done;
+		if (!readMemory32(aligned, &word))
+		{
+			last_error_ = "Memory batch read failed";
+			return false;
+		}
 		words[aligned] = word;
-	}
-
-	ok = true;
-done:
-	endDmiBatch();
-	if (!ok)
-	{
-		last_error_ = "Memory batch read failed";
-		return false;
 	}
 
 	for (const auto& [address, size] : entries)

--- a/src/EspProbe/riscv/EspRiscvDm.cpp
+++ b/src/EspProbe/riscv/EspRiscvDm.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace esp_probe
@@ -53,9 +54,30 @@ bool readIdcode(EspJtagTap& tap, const EspChipProfile& profile, uint32_t* idcode
 	return true;
 }
 
+uint32_t packRawValue(uint32_t address, uint8_t size, uint32_t word)
+{
+	const uint8_t shift = static_cast<uint8_t>((address & 3u) * 8u);
+	if (size == 1)
+		return (word >> shift) & 0xffu;
+	if (size == 2)
+		return (word >> shift) & 0xffffu;
+	return word;
+}
+
 }  // namespace
 
 EspRiscvDm::EspRiscvDm(EspJtagTap& tap, const EspChipProfile& profile) : tap_(tap), profile_(profile) {}
+
+bool EspRiscvDm::beginDmiBatch()
+{
+	batch_active_ = selectDbusIr();
+	return batch_active_;
+}
+
+void EspRiscvDm::endDmiBatch()
+{
+	batch_active_ = false;
+}
 
 bool EspRiscvDm::selectDbusIr()
 {
@@ -222,6 +244,8 @@ bool EspRiscvDm::init()
 	}
 	log_step("sbcs", sbcs, 0);
 
+	sb_sba_v1_ = (get_field_u32(sbcs, kDmSbCsSbVersion) >> 29) == kDmSbCsSbVersion10;
+
 	return true;
 }
 
@@ -238,7 +262,7 @@ void EspRiscvDm::shutdown()
 
 uint32_t EspRiscvDm::dmiScan(uint32_t op, uint32_t address, uint32_t data_out, uint32_t* data_in)
 {
-	if (!selectDbusIr())
+	if (!batch_active_ && !selectDbusIr())
 		return kDmiStatusFailed;
 
 	const unsigned dr_bits = dmiDrBits();
@@ -308,12 +332,7 @@ bool EspRiscvDm::dmiWrite(uint32_t address, uint32_t value)
 
 bool EspRiscvDm::readMemory32(uint32_t address, uint32_t* value)
 {
-	uint32_t sbcs = 0;
-	if (!dmiRead(kDmSbCs, &sbcs))
-		return false;
-
-	const uint32_t sbversion = get_field_u32(sbcs, kDmSbCsSbVersion) >> 29;
-	if (sbversion == kDmSbCsSbVersion10)
+	if (sb_sba_v1_)
 	{
 		uint32_t sbcs_write = set_field_u32(0, kDmSbCsSbReadOnAddr, 1u);
 		sbcs_write = set_field_u32(sbcs_write, kDmSbCsSbAccess, 2u);
@@ -327,14 +346,76 @@ bool EspRiscvDm::readMemory32(uint32_t address, uint32_t* value)
 		if (!dmiWrite(kDmSbAddress0, address))
 			return false;
 
-		sbcs = set_field_u32(sbcs, kDmSbCsSbAccess, 2u);
+		uint32_t sbcs = set_field_u32(0, kDmSbCsSbAccess, 2u);
 		sbcs = set_field_u32(sbcs, kDmSbCsSbSingleRead, 1u);
 		if (!dmiWrite(kDmSbCs, sbcs))
 			return false;
 	}
 
-	if (!dmiRead(kDmSbData0, value))
+	return dmiRead(kDmSbData0, value);
+}
+
+bool EspRiscvDm::readMemoryBatch(const std::vector<MemoryEntry>& entries, std::unordered_map<uint32_t, uint32_t>& values)
+{
+	values.clear();
+	if (entries.empty())
+		return true;
+
+	if (!beginDmiBatch())
+	{
+		last_error_ = "DMI batch start failed";
 		return false;
+	}
+
+	bool ok = false;
+	std::unordered_map<uint32_t, uint32_t> words;
+
+	if (sb_sba_v1_)
+	{
+		uint32_t sbcs_write = set_field_u32(0, kDmSbCsSbReadOnAddr, 1u);
+		sbcs_write = set_field_u32(sbcs_write, kDmSbCsSbAccess, 2u);
+		if (!dmiWrite(kDmSbCs, sbcs_write))
+			goto done;
+	}
+
+	for (const auto& [address, size] : entries)
+	{
+		(void)size;
+		const uint32_t aligned = address & ~3u;
+		if (words.contains(aligned))
+			continue;
+
+		if (!sb_sba_v1_)
+		{
+			if (!dmiWrite(kDmSbAddress0, aligned))
+				goto done;
+			uint32_t sbcs = set_field_u32(0, kDmSbCsSbAccess, 2u);
+			sbcs = set_field_u32(sbcs, kDmSbCsSbSingleRead, 1u);
+			if (!dmiWrite(kDmSbCs, sbcs))
+				goto done;
+		}
+		else if (!dmiWrite(kDmSbAddress0, aligned))
+		{
+			goto done;
+		}
+
+		uint32_t word = 0;
+		if (!dmiRead(kDmSbData0, &word))
+			goto done;
+		words[aligned] = word;
+	}
+
+	ok = true;
+done:
+	endDmiBatch();
+	if (!ok)
+	{
+		last_error_ = "Memory batch read failed";
+		return false;
+	}
+
+	for (const auto& [address, size] : entries)
+		values[address] = packRawValue(address, size, words[address & ~3u]);
 	return true;
 }
 

--- a/src/EspProbe/riscv/EspRiscvDm.cpp
+++ b/src/EspProbe/riscv/EspRiscvDm.cpp
@@ -1,0 +1,393 @@
+#include "EspRiscvDm.hpp"
+
+#include "EspJtagTap.hpp"
+#include "esp_bit_utils.hpp"
+#include "esp_riscv_regs.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace esp_probe
+{
+
+namespace
+{
+
+void log_step(const char* msg, uint32_t a = 0, uint32_t b = 0)
+{
+	if (!std::getenv("ESP_PROBE_VERBOSE"))
+		return;
+	std::fprintf(stderr, "[esp_probe] %s", msg);
+	if (a || b)
+		std::fprintf(stderr, " 0x%08x 0x%08x", a, b);
+	std::fprintf(stderr, "\n");
+}
+
+bool readIdcode(EspJtagTap& tap, const EspChipProfile& profile, uint32_t* idcode, std::string* err)
+{
+	std::vector<uint8_t> ir;
+	ir.reserve(profile.tap_count);
+	for (unsigned t = 0; t < profile.tap_count; ++t)
+		ir.push_back(t == profile.cpu_tap_index ? kIrIdcode : kIrBypass);
+	if (!tap.irScan(ir, profile.ir_len))
+	{
+		if (err)
+			*err = "IDCODE IR scan failed";
+		return false;
+	}
+
+	const unsigned dr_bits = (profile.tap_count > 1 ? profile.tap_count - 1 : 0) + 32;
+	std::vector<uint8_t> out_buf((dr_bits + 7) / 8, 0);
+	std::vector<uint8_t> in_buf(out_buf.size(), 0);
+	if (!tap.drScan(dr_bits, out_buf.data(), in_buf.data()))
+	{
+		if (err)
+			*err = "IDCODE DR scan failed";
+		return false;
+	}
+
+	const unsigned bypass = profile.tap_count > 1 ? profile.tap_count - 1 : 0;
+	*idcode = buf_get_u32(in_buf.data(), bypass, 32);
+	return true;
+}
+
+}  // namespace
+
+EspRiscvDm::EspRiscvDm(EspJtagTap& tap, const EspChipProfile& profile) : tap_(tap), profile_(profile) {}
+
+bool EspRiscvDm::selectDbusIr()
+{
+	std::vector<uint8_t> ir;
+	ir.reserve(profile_.tap_count);
+	for (unsigned t = 0; t < profile_.tap_count; ++t)
+		ir.push_back(t == profile_.cpu_tap_index ? kIrDbus : kIrBypass);
+	if (!tap_.irScan(ir, profile_.ir_len))
+		return false;
+	tap_.runIdle(2);
+	return true;
+}
+
+bool EspRiscvDm::selectDtmControlIr()
+{
+	std::vector<uint8_t> ir;
+	ir.reserve(profile_.tap_count);
+	for (unsigned t = 0; t < profile_.tap_count; ++t)
+		ir.push_back(t == profile_.cpu_tap_index ? kIrDtmControl : kIrBypass);
+	if (!tap_.irScan(ir, profile_.ir_len))
+		return false;
+	tap_.runIdle(2);
+	return true;
+}
+
+unsigned EspRiscvDm::bypassDrBits() const
+{
+	unsigned bits = 0;
+	for (unsigned t = 0; t < profile_.tap_count; ++t)
+	{
+		if (t != profile_.cpu_tap_index)
+			bits += 1;
+	}
+	return bits;
+}
+
+unsigned EspRiscvDm::dmiDrBits() const
+{
+	return bypassDrBits() + abits_ + kDtmDmiDataLength + kDtmDmiOpLength;
+}
+
+bool EspRiscvDm::dtmControlScan(uint32_t out, uint32_t* in)
+{
+	if (!selectDtmControlIr())
+		return false;
+
+	const unsigned dr_bits = bypassDrBits() + 32;
+	std::vector<uint8_t> out_buf((dr_bits + 7) / 8, 0);
+	std::vector<uint8_t> in_buf(out_buf.size(), 0);
+	buf_set_u32(out_buf.data(), bypassDrBits(), 32, out);
+
+	if (!tap_.drScan(dr_bits, out_buf.data(), in_buf.data()))
+		return false;
+
+	selectDbusIr();
+	if (in)
+		*in = buf_get_u32(in_buf.data(), bypassDrBits(), 32);
+	return true;
+}
+
+bool EspRiscvDm::init()
+{
+	last_error_.clear();
+	tap_.reset();
+	tap_.runIdle(10);
+
+	uint32_t idcode = 0;
+	if (!readIdcode(tap_, profile_, &idcode, nullptr))
+	{
+		last_error_ = "IDCODE verify failed";
+		return false;
+	}
+	log_step("idcode", idcode, profile_.idcode);
+	if ((idcode & 0xfffffffu) != (profile_.idcode & 0xfffffffu))
+	{
+		last_error_ = "IDCODE mismatch (wrong chip profile?)";
+		return false;
+	}
+
+	uint32_t dtmcs = 0;
+	if (!dtmControlScan(0, &dtmcs))
+	{
+		last_error_ = "DTMCS read failed";
+		return false;
+	}
+	if ((dtmcs & kDtmDtmcsVersion) != kDtmDtmcsVersion10 && ((dtmcs >> 1) & kDtmDtmcsVersion) == kDtmDtmcsVersion10)
+		dtmcs >>= 1;
+	log_step("dtmcs", dtmcs, 0);
+
+	if (dtmcs == 0)
+	{
+		last_error_ = "DTMCS is zero (JTAG not connected?)";
+		return false;
+	}
+
+	const uint32_t version = get_field_u32(dtmcs, kDtmDtmcsVersion);
+	if (version != kDtmDtmcsVersion10)
+	{
+		last_error_ = "Unsupported DTM version";
+		return false;
+	}
+
+	abits_ = get_field_u32(dtmcs, kDtmDtmcsAbits) >> 4;
+	if (abits_ == 0)
+		abits_ = 7;
+
+	dmi_busy_delay_ = get_field_u32(dtmcs, kDtmDtmcsIdle) >> 12;
+
+	if (!selectDbusIr())
+	{
+		last_error_ = "Failed to select DBUS IR";
+		return false;
+	}
+	tap_.runIdle(2);
+
+	if (!dmiWrite(kDmDmControl, 0))
+	{
+		last_error_ = "dmcontrol clear failed";
+		return false;
+	}
+
+	if (!dmiWrite(kDmDmControl, kDmControlDmActive))
+	{
+		last_error_ = "dmactive set failed";
+		return false;
+	}
+
+	const uint32_t dmcontrol_sel = kDmControlDmActive | kDmControlHartSelLo | kDmControlHartSelHi | kDmControlHaSel;
+	if (!dmiWrite(kDmDmControl, dmcontrol_sel))
+	{
+		last_error_ = "dmcontrol hartsel failed";
+		return false;
+	}
+
+	uint32_t dmcontrol = 0;
+	if (!dmiRead(kDmDmControl, &dmcontrol))
+	{
+		last_error_ = "dmcontrol read failed";
+		return false;
+	}
+	log_step("dmcontrol", dmcontrol, 0);
+
+	if ((dmcontrol & kDmControlDmActive) == 0)
+	{
+		char msg[80];
+		std::snprintf(msg, sizeof(msg), "Debug module did not activate (dmcontrol=0x%08x)", dmcontrol);
+		last_error_ = msg;
+		return false;
+	}
+
+	uint32_t dmstatus = 0;
+	if (!dmiRead(kDmDmStatus, &dmstatus))
+	{
+		last_error_ = "dmstatus read failed";
+		return false;
+	}
+	log_step("dmstatus", dmstatus, 0);
+
+	uint32_t sbcs = 0;
+	if (!dmiRead(kDmSbCs, &sbcs))
+	{
+		last_error_ = "sbcs read failed";
+		return false;
+	}
+	log_step("sbcs", sbcs, 0);
+
+	return true;
+}
+
+void EspRiscvDm::shutdown()
+{
+	if (!selectDbusIr())
+		return;
+
+	const uint32_t resume = kDmControlDmActive | kDmControlResumeReq;
+	dmiWrite(kDmDmControl, resume);
+	tap_.runIdle(10);
+	dmiWrite(kDmDmControl, 0);
+}
+
+uint32_t EspRiscvDm::dmiScan(uint32_t op, uint32_t address, uint32_t data_out, uint32_t* data_in)
+{
+	if (!selectDbusIr())
+		return kDmiStatusFailed;
+
+	const unsigned dr_bits = dmiDrBits();
+	std::vector<uint8_t> out_buf((dr_bits + 7) / 8, 0);
+	std::vector<uint8_t> in_buf(out_buf.size(), 0);
+
+	const unsigned dmi_offset = bypassDrBits();
+	buf_set_u32(out_buf.data(), dmi_offset + kDmiOpOffset, kDtmDmiOpLength, op);
+	buf_set_u32(out_buf.data(), dmi_offset + kDmiDataOffset, kDtmDmiDataLength, data_out);
+	buf_set_u32(out_buf.data(), dmi_offset + kDmiAddressOffset, abits_, address);
+
+	if (!tap_.drScan(dr_bits, out_buf.data(), in_buf.data()))
+		return kDmiStatusFailed;
+
+	if (dmi_busy_delay_ > 0)
+		tap_.runIdle(dmi_busy_delay_);
+
+	const uint32_t status = buf_get_u32(in_buf.data(), dmi_offset + kDmiOpOffset, kDtmDmiOpLength);
+	if (data_in)
+		*data_in = buf_get_u32(in_buf.data(), dmi_offset + kDmiDataOffset, kDtmDmiDataLength);
+	return status;
+}
+
+bool EspRiscvDm::dmiOp(uint32_t op, uint32_t address, uint32_t data_out, uint32_t* data_in)
+{
+	for (unsigned attempt = 0; attempt < 32; ++attempt)
+	{
+		uint32_t read_back = 0;
+		const uint32_t status = dmiScan(op, address, data_out, &read_back);
+		if (status == kDmiStatusBusy)
+		{
+			dmi_busy_delay_ += dmi_busy_delay_ / 10 + 1;
+			continue;
+		}
+		if (status != kDmiStatusSuccess)
+		{
+			last_error_ = "DMI op failed status=" + std::to_string(status);
+			return false;
+		}
+
+		uint32_t nop_data = 0;
+		const uint32_t nop_status = dmiScan(kDmiOpNop, 0, 0, &nop_data);
+		if (nop_status == kDmiStatusBusy)
+		{
+			dmi_busy_delay_ += dmi_busy_delay_ / 10 + 1;
+			continue;
+		}
+		if (nop_status != kDmiStatusSuccess)
+			return false;
+
+		if (data_in)
+			*data_in = nop_data;
+		return true;
+	}
+	return false;
+}
+
+bool EspRiscvDm::dmiRead(uint32_t address, uint32_t* value)
+{
+	return dmiOp(kDmiOpRead, address, 0, value);
+}
+
+bool EspRiscvDm::dmiWrite(uint32_t address, uint32_t value)
+{
+	return dmiOp(kDmiOpWrite, address, value, nullptr);
+}
+
+bool EspRiscvDm::readMemory32(uint32_t address, uint32_t* value)
+{
+	uint32_t sbcs = 0;
+	if (!dmiRead(kDmSbCs, &sbcs))
+		return false;
+
+	const uint32_t sbversion = get_field_u32(sbcs, kDmSbCsSbVersion) >> 29;
+	if (sbversion == kDmSbCsSbVersion10)
+	{
+		uint32_t sbcs_write = set_field_u32(0, kDmSbCsSbReadOnAddr, 1u);
+		sbcs_write = set_field_u32(sbcs_write, kDmSbCsSbAccess, 2u);
+		if (!dmiWrite(kDmSbCs, sbcs_write))
+			return false;
+		if (!dmiWrite(kDmSbAddress0, address))
+			return false;
+	}
+	else
+	{
+		if (!dmiWrite(kDmSbAddress0, address))
+			return false;
+
+		sbcs = set_field_u32(sbcs, kDmSbCsSbAccess, 2u);
+		sbcs = set_field_u32(sbcs, kDmSbCsSbSingleRead, 1u);
+		if (!dmiWrite(kDmSbCs, sbcs))
+			return false;
+	}
+
+	if (!dmiRead(kDmSbData0, value))
+		return false;
+	return true;
+}
+
+bool EspRiscvDm::writeMemory32(uint32_t address, uint32_t value)
+{
+	uint32_t sbcs = 0;
+	if (!dmiRead(kDmSbCs, &sbcs))
+		return false;
+
+	if (!dmiWrite(kDmSbAddress0, address))
+		return false;
+
+	sbcs = set_field_u32(sbcs, kDmSbCsSbAccess, 2u);
+	if (!dmiWrite(kDmSbCs, sbcs))
+		return false;
+
+	return dmiWrite(kDmSbData0, value);
+}
+
+bool EspRiscvDm::readMemory(uint32_t address, uint8_t* buf, uint32_t size)
+{
+	if (size == 0 || size > 4)
+		return false;
+
+	uint32_t word = 0;
+	if (!readMemory32(address & ~3u, &word))
+		return false;
+
+	const uint8_t shift = static_cast<uint8_t>((address & 3u) * 8u);
+	for (uint32_t i = 0; i < size; ++i)
+		buf[i] = static_cast<uint8_t>((word >> (shift + i * 8u)) & 0xffu);
+	return true;
+}
+
+bool EspRiscvDm::writeMemory(uint32_t address, const uint8_t* buf, uint32_t size)
+{
+	if (size == 0 || size > 4)
+		return false;
+
+	uint32_t word = 0;
+	if (size < 4 || (address & 3u) != 0)
+	{
+		if (!readMemory32(address & ~3u, &word))
+			return false;
+	}
+
+	const uint8_t shift = static_cast<uint8_t>((address & 3u) * 8u);
+	for (uint32_t i = 0; i < size; ++i)
+	{
+		const uint32_t mask = ~(0xffu << (shift + i * 8u));
+		word = (word & mask) | (static_cast<uint32_t>(buf[i]) << (shift + i * 8u));
+	}
+	return writeMemory32(address & ~3u, word);
+}
+
+}  // namespace esp_probe

--- a/src/EspProbe/riscv/EspRiscvDm.cpp
+++ b/src/EspProbe/riscv/EspRiscvDm.cpp
@@ -262,7 +262,7 @@ void EspRiscvDm::shutdown()
 
 uint32_t EspRiscvDm::dmiScan(uint32_t op, uint32_t address, uint32_t data_out, uint32_t* data_in)
 {
-	if (!batch_active_ && !selectDbusIr())
+	if (!selectDbusIr())
 		return kDmiStatusFailed;
 
 	const unsigned dr_bits = dmiDrBits();

--- a/src/EspProbe/riscv/EspRiscvDm.hpp
+++ b/src/EspProbe/riscv/EspRiscvDm.hpp
@@ -3,6 +3,9 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace esp_probe
 {
@@ -17,11 +20,16 @@ class EspRiscvDm
 
 	bool init();
 	void shutdown();
+	using MemoryEntry = std::pair<uint32_t, uint8_t>;
+
 	bool readMemory(uint32_t address, uint8_t* buf, uint32_t size);
+	bool readMemoryBatch(const std::vector<MemoryEntry>& entries, std::unordered_map<uint32_t, uint32_t>& values);
 	bool writeMemory(uint32_t address, const uint8_t* buf, uint32_t size);
 	const std::string& lastError() const { return last_error_; }
 
    private:
+	bool beginDmiBatch();
+	void endDmiBatch();
 	bool selectDbusIr();
 	bool selectDtmControlIr();
 	unsigned bypassDrBits() const;
@@ -38,6 +46,8 @@ class EspRiscvDm
 	const EspChipProfile& profile_;
 	unsigned abits_ = 7;
 	unsigned dmi_busy_delay_ = 0;
+	bool batch_active_ = false;
+	bool sb_sba_v1_ = false;
 	std::string last_error_;
 };
 

--- a/src/EspProbe/riscv/EspRiscvDm.hpp
+++ b/src/EspProbe/riscv/EspRiscvDm.hpp
@@ -28,8 +28,6 @@ class EspRiscvDm
 	const std::string& lastError() const { return last_error_; }
 
    private:
-	bool beginDmiBatch();
-	void endDmiBatch();
 	bool selectDbusIr();
 	bool selectDtmControlIr();
 	unsigned bypassDrBits() const;
@@ -46,7 +44,6 @@ class EspRiscvDm
 	const EspChipProfile& profile_;
 	unsigned abits_ = 7;
 	unsigned dmi_busy_delay_ = 0;
-	bool batch_active_ = false;
 	bool sb_sba_v1_ = false;
 	std::string last_error_;
 };

--- a/src/EspProbe/riscv/EspRiscvDm.hpp
+++ b/src/EspProbe/riscv/EspRiscvDm.hpp
@@ -1,0 +1,46 @@
+#ifndef ESP_RISCV_DM_HPP
+#define ESP_RISCV_DM_HPP
+
+#include <cstdint>
+#include <string>
+
+namespace esp_probe
+{
+
+struct EspChipProfile;
+class EspJtagTap;
+
+class EspRiscvDm
+{
+   public:
+	EspRiscvDm(EspJtagTap& tap, const EspChipProfile& profile);
+
+	bool init();
+	void shutdown();
+	bool readMemory(uint32_t address, uint8_t* buf, uint32_t size);
+	bool writeMemory(uint32_t address, const uint8_t* buf, uint32_t size);
+	const std::string& lastError() const { return last_error_; }
+
+   private:
+	bool selectDbusIr();
+	bool selectDtmControlIr();
+	unsigned bypassDrBits() const;
+	unsigned dmiDrBits() const;
+	bool dtmControlScan(uint32_t out, uint32_t* in);
+	uint32_t dmiScan(uint32_t op, uint32_t address, uint32_t data_out, uint32_t* data_in);
+	bool dmiOp(uint32_t op, uint32_t address, uint32_t data_out, uint32_t* data_in);
+	bool dmiRead(uint32_t address, uint32_t* value);
+	bool dmiWrite(uint32_t address, uint32_t value);
+	bool readMemory32(uint32_t address, uint32_t* value);
+	bool writeMemory32(uint32_t address, uint32_t value);
+
+	EspJtagTap& tap_;
+	const EspChipProfile& profile_;
+	unsigned abits_ = 7;
+	unsigned dmi_busy_delay_ = 0;
+	std::string last_error_;
+};
+
+}  // namespace esp_probe
+
+#endif

--- a/src/EspProbe/usb/EspUsbJtagTransport.cpp
+++ b/src/EspProbe/usb/EspUsbJtagTransport.cpp
@@ -1,0 +1,561 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Adapted from OpenOCD src/jtag/drivers/esp_usb_jtag.c
+
+#include "EspUsbJtagTransport.hpp"
+
+#include <libusb-1.0/libusb.h>
+
+#include <cstring>
+
+namespace esp_probe
+{
+
+namespace
+{
+
+constexpr unsigned kLibusbTimeoutMs = 1000;
+constexpr unsigned kCmdRepMaxReps = 1024;
+constexpr unsigned kVendJtagSetDiv = 0;
+
+constexpr unsigned CMD_CLK(unsigned cap, unsigned tdi, unsigned tms)
+{
+	return (cap ? 4u : 0u) | (tms ? 2u : 0u) | (tdi ? 1u : 0u);
+}
+constexpr unsigned CMD_RST(unsigned srst) { return 0x8u | (srst ? 1u : 0u); }
+constexpr unsigned CMD_FLUSH = 0xA;
+constexpr unsigned CMD_REP(unsigned r) { return 0xCu | ((r) & 3u); }
+
+struct JtagProtoCapsHdr
+{
+	uint8_t proto_ver;
+	uint8_t length;
+} __attribute__((packed));
+
+struct JtagGenHdr
+{
+	uint8_t type;
+	uint8_t length;
+} __attribute__((packed));
+
+struct JtagProtoCapsSpeedApb
+{
+	uint8_t type;
+	uint8_t length;
+	uint8_t apb_speed_10khz[2];
+	uint8_t div_min[2];
+	uint8_t div_max[2];
+} __attribute__((packed));
+
+constexpr uint8_t kJtagProtoCapsSpeedApbType = 1;
+constexpr unsigned kJtagBuiltinDescrStartOff = 0;
+constexpr unsigned kJtagProtoCapsDataLen = 255;
+
+bool isPlaceholderSerial(const std::string& serial)
+{
+	return serial.empty() || serial.find("No debug probes found") != std::string::npos;
+}
+
+void detachKernelIfNeeded(libusb_device_handle* handle, uint8_t interface)
+{
+	if (libusb_kernel_driver_active(handle, interface) == 1)
+		libusb_detach_kernel_driver(handle, interface);
+}
+
+}  // namespace
+
+EspUsbJtagTransport::~EspUsbJtagTransport()
+{
+	close();
+}
+
+bool EspUsbJtagTransport::ensureContext()
+{
+	if (ctx_ != nullptr)
+		return true;
+	const int rc = libusb_init(&ctx_);
+	if (rc != 0)
+	{
+		last_error_ = std::string("libusb_init failed: ") + libusb_strerror(static_cast<libusb_error>(rc));
+		return false;
+	}
+	return true;
+}
+
+void EspUsbJtagTransport::close()
+{
+	if (handle_)
+	{
+		libusb_release_interface(handle_, jtag_interface_);
+		if (libusb_kernel_driver_active(handle_, jtag_interface_) == 0)
+			libusb_attach_kernel_driver(handle_, jtag_interface_);
+		libusb_close(handle_);
+		handle_ = nullptr;
+	}
+	if (ctx_)
+	{
+		libusb_exit(ctx_);
+		ctx_ = nullptr;
+	}
+	jtag_interface_ = 0;
+	read_ep_ = 0;
+	write_ep_ = 0;
+}
+
+std::vector<std::string> EspUsbJtagTransport::listDevices()
+{
+	std::vector<std::string> serials;
+	if (!ensureContext())
+		return serials;
+
+	libusb_device** list = nullptr;
+	const ssize_t count = libusb_get_device_list(ctx_, &list);
+	for (ssize_t i = 0; i < count; ++i)
+	{
+		libusb_device_descriptor desc{};
+		if (libusb_get_device_descriptor(list[i], &desc) != 0)
+			continue;
+		if (desc.idVendor != kVid || desc.idProduct != kPid)
+			continue;
+
+		libusb_device_handle* dev = nullptr;
+		if (libusb_open(list[i], &dev) != 0)
+			continue;
+
+		char serial[256]{};
+		if (desc.iSerialNumber != 0)
+			libusb_get_string_descriptor_ascii(dev, desc.iSerialNumber, reinterpret_cast<unsigned char*>(serial), sizeof(serial));
+
+		if (serial[0] != '\0')
+			serials.emplace_back(serial);
+		else
+			serials.emplace_back("esp-usb-jtag");
+
+		libusb_close(dev);
+	}
+
+	libusb_free_device_list(list, 1);
+	return serials;
+}
+
+bool EspUsbJtagTransport::ensureConfiguration(libusb_device* dev)
+{
+	libusb_config_descriptor* config = nullptr;
+	if (libusb_get_config_descriptor(dev, 0, &config) != 0 || config == nullptr)
+	{
+		last_error_ = "Failed to read USB configuration descriptor";
+		return false;
+	}
+
+	int current = -1;
+	const int cfg_rc = libusb_get_configuration(handle_, &current);
+	if (cfg_rc != 0)
+	{
+		libusb_free_config_descriptor(config);
+		last_error_ = std::string("libusb_get_configuration failed: ") + libusb_strerror(static_cast<libusb_error>(cfg_rc));
+		return false;
+	}
+
+	if (current != static_cast<int>(config->bConfigurationValue))
+	{
+		const int set_rc = libusb_set_configuration(handle_, config->bConfigurationValue);
+		if (set_rc != 0 && set_rc != LIBUSB_ERROR_BUSY)
+		{
+			libusb_free_config_descriptor(config);
+			last_error_ = std::string("libusb_set_configuration failed: ") + libusb_strerror(static_cast<libusb_error>(set_rc));
+			return false;
+		}
+	}
+
+	libusb_free_config_descriptor(config);
+	return true;
+}
+
+bool EspUsbJtagTransport::claimJtagInterface(libusb_device* dev)
+{
+	libusb_config_descriptor* config = nullptr;
+	if (libusb_get_active_config_descriptor(dev, &config) != 0)
+	{
+		if (libusb_get_config_descriptor(dev, 0, &config) != 0 || config == nullptr)
+		{
+			last_error_ = "Failed to read active USB configuration";
+			return false;
+		}
+	}
+
+	read_ep_ = 0;
+	write_ep_ = 0;
+	jtag_interface_ = 0;
+
+	for (int i = 0; i < config->bNumInterfaces; ++i)
+	{
+		const auto& alt = config->interface[i].altsetting[0];
+		if (alt.bInterfaceClass != kJtagIfaceClass || alt.bInterfaceSubClass != kJtagIfaceSubclass ||
+			alt.bInterfaceProtocol != kJtagIfaceProtocol)
+			continue;
+
+		unsigned in_ep = 0;
+		unsigned out_ep = 0;
+		for (int ep = 0; ep < alt.bNumEndpoints; ++ep)
+		{
+			const auto& endpoint = alt.endpoint[ep];
+			if ((endpoint.bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) != LIBUSB_TRANSFER_TYPE_BULK)
+				continue;
+			if (endpoint.bEndpointAddress & LIBUSB_ENDPOINT_IN)
+				in_ep = endpoint.bEndpointAddress;
+			else
+				out_ep = endpoint.bEndpointAddress;
+		}
+
+		if (in_ep == 0 || out_ep == 0)
+			continue;
+
+		detachKernelIfNeeded(handle_, alt.bInterfaceNumber);
+
+		const int claim_rc = libusb_claim_interface(handle_, alt.bInterfaceNumber);
+		if (claim_rc != 0)
+		{
+			last_error_ = std::string("libusb_claim_interface failed: ") + libusb_strerror(static_cast<libusb_error>(claim_rc)) +
+				" (close idf.py monitor / openocd if running)";
+			libusb_free_config_descriptor(config);
+			return false;
+		}
+
+		jtag_interface_ = alt.bInterfaceNumber;
+		read_ep_ = in_ep;
+		write_ep_ = out_ep;
+		libusb_free_config_descriptor(config);
+		return true;
+	}
+
+	libusb_free_config_descriptor(config);
+	last_error_ = "ESP USB-JTAG bulk interface not found";
+	return false;
+}
+
+bool EspUsbJtagTransport::readCapsDescriptor()
+{
+	uint8_t caps[kJtagProtoCapsDataLen]{};
+	const int caps_len = libusb_control_transfer(handle_,
+		static_cast<uint8_t>(LIBUSB_ENDPOINT_IN | LIBUSB_REQUEST_TYPE_STANDARD | LIBUSB_RECIPIENT_DEVICE),
+		LIBUSB_REQUEST_GET_DESCRIPTOR,
+		kCapsDescriptor,
+		0,
+		caps,
+		kJtagProtoCapsDataLen,
+		kLibusbTimeoutMs);
+
+	base_speed_khz_ = 24000;
+	div_min_ = 1;
+	div_max_ = 255;
+
+	if (caps_len <= 0)
+		return true;
+
+	unsigned p = kJtagBuiltinDescrStartOff;
+	if (p + sizeof(JtagProtoCapsHdr) > static_cast<unsigned>(caps_len))
+		return true;
+
+	p += reinterpret_cast<JtagProtoCapsHdr*>(caps + p)->length;
+	while (p + sizeof(JtagGenHdr) <= static_cast<unsigned>(caps_len))
+	{
+		const auto* hdr = reinterpret_cast<const JtagGenHdr*>(caps + p);
+		if (hdr->type == kJtagProtoCapsSpeedApbType && hdr->length >= sizeof(JtagProtoCapsSpeedApb))
+		{
+			const auto* speed = reinterpret_cast<const JtagProtoCapsSpeedApb*>(caps + p);
+			const uint32_t apb_10khz = static_cast<uint32_t>(speed->apb_speed_10khz[0]) | (static_cast<uint32_t>(speed->apb_speed_10khz[1]) << 8);
+			base_speed_khz_ = apb_10khz * 10 / 2;
+			div_min_ = static_cast<uint16_t>(speed->div_min[0]) | (static_cast<uint16_t>(speed->div_min[1]) << 8);
+			div_max_ = static_cast<uint16_t>(speed->div_max[0]) | (static_cast<uint16_t>(speed->div_max[1]) << 8);
+			break;
+		}
+		p += hdr->length;
+	}
+	return true;
+}
+
+bool EspUsbJtagTransport::open(const std::string& serial)
+{
+	close();
+	last_error_.clear();
+
+	if (!ensureContext())
+		return false;
+
+	libusb_device** list = nullptr;
+	const ssize_t count = libusb_get_device_list(ctx_, &list);
+
+	for (ssize_t i = 0; i < count; ++i)
+	{
+		libusb_device_descriptor desc{};
+		if (libusb_get_device_descriptor(list[i], &desc) != 0)
+			continue;
+		if (desc.idVendor != kVid || desc.idProduct != kPid)
+			continue;
+
+		libusb_device_handle* dev = nullptr;
+		const int open_rc = libusb_open(list[i], &dev);
+		if (open_rc != 0)
+		{
+			last_error_ = std::string("libusb_open failed: ") + libusb_strerror(static_cast<libusb_error>(open_rc));
+			continue;
+		}
+
+		if (!isPlaceholderSerial(serial))
+		{
+			char dev_serial[256]{};
+			if (desc.iSerialNumber != 0)
+				libusb_get_string_descriptor_ascii(dev, desc.iSerialNumber, reinterpret_cast<unsigned char*>(dev_serial), sizeof(dev_serial));
+			if (serial != dev_serial)
+			{
+				libusb_close(dev);
+				continue;
+			}
+		}
+
+		handle_ = dev;
+		if (!ensureConfiguration(list[i]) || !claimJtagInterface(list[i]))
+		{
+			libusb_close(dev);
+			handle_ = nullptr;
+			continue;
+		}
+
+		readCapsDescriptor();
+
+		out_nibbles_ = 0;
+		in_rd_ = in_wr_ = in_pos_bits_ = 0;
+		pending_in_bits_ = 0;
+		prev_cmd_ = 0;
+		prev_cmd_rep_ = 0;
+		std::memset(in_buf_bits_, 0, sizeof(in_buf_bits_));
+
+		setSpeedKhz(base_speed_khz_);
+		libusb_free_device_list(list, 1);
+		return true;
+	}
+
+	libusb_free_device_list(list, 1);
+	if (last_error_.empty())
+		last_error_ = "ESP USB-JTAG device not found (303a:1001)";
+	return false;
+}
+
+bool EspUsbJtagTransport::setSpeedKhz(uint32_t speed_khz)
+{
+	if (!handle_)
+		return false;
+
+	if (speed_khz == 0)
+		speed_khz = base_speed_khz_;
+
+	uint32_t div = base_speed_khz_ / speed_khz;
+	if (div < div_min_)
+		div = div_min_;
+	if (div > div_max_)
+		div = div_max_;
+
+	const uint16_t div16 = static_cast<uint16_t>(div);
+	return libusb_control_transfer(handle_,
+		static_cast<uint8_t>(LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT),
+		kVendJtagSetDiv,
+		div16,
+		jtag_interface_,
+		nullptr,
+		0,
+		kLibusbTimeoutMs) >= 0;
+}
+
+bool EspUsbJtagTransport::sendOutBuffer()
+{
+	unsigned ct = out_nibbles_ / 2;
+	unsigned written = 0;
+	while (written < ct)
+	{
+		int transferred = 0;
+		const int ret = libusb_bulk_transfer(handle_, static_cast<unsigned char>(write_ep_), out_buf_ + written, ct - written, &transferred, kLibusbTimeoutMs);
+		if (ret != 0)
+			return false;
+		written += static_cast<unsigned>(transferred);
+	}
+	out_nibbles_ = 0;
+
+	while (pending_in_bits_ > (kInBufSize + hw_in_fifo_len_ - 1) * 8)
+	{
+		if (!recvInBuffer())
+			return false;
+	}
+	return true;
+}
+
+bool EspUsbJtagTransport::recvInBuffer()
+{
+	if (in_buf_bits_[in_wr_] != 0)
+		return false;
+
+	unsigned ct = (pending_in_bits_ + 7) / 8;
+	if (ct > kInBufSize)
+		ct = kInBufSize;
+	if (ct == 0)
+		return true;
+
+	in_buf_bits_[in_wr_] = 0;
+	unsigned recvd = 0;
+	unsigned retries = 0;
+	while (recvd < ct)
+	{
+		int transferred = 0;
+		const int ret = libusb_bulk_transfer(handle_, static_cast<unsigned char>(read_ep_), in_buf_[in_wr_] + recvd, ct - recvd, &transferred, kLibusbTimeoutMs);
+		if (ret != 0)
+		{
+			last_error_ = std::string("libusb bulk read failed: ") + libusb_strerror(static_cast<libusb_error>(ret));
+			return false;
+		}
+		if (transferred == 0)
+		{
+			if (++retries > 10)
+				return false;
+			continue;
+		}
+		retries = 0;
+
+		unsigned bits_in_buf = pending_in_bits_;
+		if (bits_in_buf > static_cast<unsigned>(transferred) * 8)
+			bits_in_buf = static_cast<unsigned>(transferred) * 8;
+		pending_in_bits_ -= bits_in_buf;
+		in_buf_bits_[in_wr_] += bits_in_buf;
+		recvd += static_cast<unsigned>(transferred);
+	}
+
+	in_wr_ = (in_wr_ + 1) % kInBufCount;
+	return true;
+}
+
+int EspUsbJtagTransport::commandAddRaw(unsigned cmd)
+{
+	if ((out_nibbles_ & 1u) == 0)
+		out_buf_[out_nibbles_ / 2] = static_cast<uint8_t>(cmd << 4);
+	else
+		out_buf_[out_nibbles_ / 2] |= static_cast<uint8_t>(cmd & 0xf);
+	out_nibbles_++;
+
+	if (out_nibbles_ == kOutBufSize * 2)
+	{
+		if (!sendOutBuffer())
+			return -1;
+	}
+	if (out_nibbles_ != 0 && out_nibbles_ % (kOutEpSize * 2) == 0 &&
+		pending_in_bits_ > (kInBufSize + hw_in_fifo_len_ - 1) * 8)
+	{
+		if (!sendOutBuffer())
+			return -1;
+	}
+	return 0;
+}
+
+int EspUsbJtagTransport::writeRleStream(unsigned cmd, int count)
+{
+	if (cmd == CMD_FLUSH)
+		count = 1;
+
+	if (commandAddRaw(cmd) != 0)
+		return -1;
+	count--;
+
+	while (count > 0)
+	{
+		if (commandAddRaw(CMD_REP(count & 3)) != 0)
+			return -1;
+		count >>= 2;
+	}
+	return 0;
+}
+
+int EspUsbJtagTransport::commandAdd(unsigned cmd)
+{
+	if (cmd == prev_cmd_ && prev_cmd_rep_ < static_cast<int>(kCmdRepMaxReps))
+	{
+		prev_cmd_rep_++;
+		return 0;
+	}
+
+	if (prev_cmd_rep_ > 0)
+	{
+		if (writeRleStream(prev_cmd_, prev_cmd_rep_) != 0)
+			return -1;
+	}
+	prev_cmd_ = cmd;
+	prev_cmd_rep_ = 1;
+	return 0;
+}
+
+int EspUsbJtagTransport::out(int tms, int tdi, bool tdo_req)
+{
+	if (commandAdd(CMD_CLK(tdo_req, tdi, tms)) != 0)
+		return -1;
+	if (tdo_req)
+		pending_in_bits_++;
+	return 0;
+}
+
+int EspUsbJtagTransport::flush()
+{
+	if (prev_cmd_rep_ > 0)
+	{
+		if (writeRleStream(prev_cmd_, prev_cmd_rep_) != 0)
+			return -1;
+		prev_cmd_rep_ = 0;
+	}
+
+	if (commandAddRaw(CMD_FLUSH) != 0)
+		return -1;
+	if (out_nibbles_ & 1u)
+	{
+		if (commandAddRaw(CMD_FLUSH) != 0)
+			return -1;
+	}
+
+	if (!sendOutBuffer())
+	{
+		last_error_ = "USB bulk write failed";
+		return -1;
+	}
+
+	while (pending_in_bits_ > 0)
+	{
+		if (!recvInBuffer())
+			return -1;
+	}
+	return 0;
+}
+
+int EspUsbJtagTransport::readTdoBit()
+{
+	if (in_rd_ == in_wr_ && in_buf_bits_[in_rd_] == 0)
+		return -1;
+
+	const int bit = (in_buf_[in_rd_][in_pos_bits_ / 8] & (1u << (in_pos_bits_ % 8))) ? 1 : 0;
+	in_pos_bits_++;
+	if (in_pos_bits_ == in_buf_bits_[in_rd_])
+	{
+		in_pos_bits_ = 0;
+		in_buf_bits_[in_rd_] = 0;
+		in_rd_ = (in_rd_ + 1) % kInBufCount;
+	}
+	return bit;
+}
+
+void EspUsbJtagTransport::clk(int tms, int tdi, bool capture_tdo)
+{
+	out(tms, tdi, capture_tdo);
+}
+
+void EspUsbJtagTransport::tapReset()
+{
+	for (int i = 0; i < 6; ++i)
+		clk(1, 0, false);
+	clk(1, 0, false);
+	clk(0, 0, false);
+	flush();
+}
+
+}  // namespace esp_probe

--- a/src/EspProbe/usb/EspUsbJtagTransport.hpp
+++ b/src/EspProbe/usb/EspUsbJtagTransport.hpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// USB-JTAG transport adapted from OpenOCD esp_usb_jtag.c (Espressif, GPL-2.0-or-later).
+
+#ifndef ESP_USB_JTAG_TRANSPORT_HPP
+#define ESP_USB_JTAG_TRANSPORT_HPP
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+struct libusb_context;
+struct libusb_device;
+struct libusb_device_handle;
+
+namespace esp_probe
+{
+
+class EspUsbJtagTransport
+{
+   public:
+	EspUsbJtagTransport() = default;
+	~EspUsbJtagTransport();
+
+	EspUsbJtagTransport(const EspUsbJtagTransport&) = delete;
+	EspUsbJtagTransport& operator=(const EspUsbJtagTransport&) = delete;
+
+	bool open(const std::string& serial = {});
+	void close();
+	bool isOpen() const { return handle_ != nullptr; }
+	const std::string& lastError() const { return last_error_; }
+
+	bool setSpeedKhz(uint32_t speed_khz);
+	std::vector<std::string> listDevices();
+
+	void clk(int tms, int tdi, bool capture_tdo);
+	int flush();
+	int readTdoBit();
+
+	void tapReset();
+
+   private:
+	static constexpr uint16_t kVid = 0x303a;
+	static constexpr uint16_t kPid = 0x1001;
+	static constexpr uint16_t kCapsDescriptor = 0x2000;
+	static constexpr uint8_t kJtagIfaceClass = 0xff;
+	static constexpr uint8_t kJtagIfaceSubclass = 0xff;
+	static constexpr uint8_t kJtagIfaceProtocol = 1;
+	static constexpr unsigned kOutEpSize = 64;
+	static constexpr unsigned kOutBufSize = kOutEpSize * 32;
+	static constexpr unsigned kInBufSize = 64;
+	static constexpr unsigned kInBufCount = 8;
+
+	libusb_context* ctx_ = nullptr;
+	libusb_device_handle* handle_ = nullptr;
+	uint8_t jtag_interface_ = 0;
+	unsigned read_ep_ = 0;
+	unsigned write_ep_ = 0;
+	std::string last_error_;
+
+	uint32_t base_speed_khz_ = 24000;
+	uint16_t div_min_ = 1;
+	uint16_t div_max_ = 255;
+
+	uint8_t out_buf_[kOutBufSize]{};
+	unsigned out_nibbles_ = 0;
+
+	uint8_t in_buf_[kInBufCount][kInBufSize]{};
+	unsigned in_buf_bits_[kInBufCount]{};
+	unsigned in_rd_ = 0;
+	unsigned in_wr_ = 0;
+	unsigned in_pos_bits_ = 0;
+	unsigned pending_in_bits_ = 0;
+
+	unsigned prev_cmd_ = 0;
+	int prev_cmd_rep_ = 0;
+	unsigned hw_in_fifo_len_ = 4;
+
+	bool ensureContext();
+	bool ensureConfiguration(libusb_device* dev);
+	bool claimJtagInterface(libusb_device* dev);
+	bool readCapsDescriptor();
+	bool sendOutBuffer();
+	bool recvInBuffer();
+	int commandAddRaw(unsigned cmd);
+	int commandAdd(unsigned cmd);
+	int writeRleStream(unsigned cmd, int count);
+	int out(int tms, int tdi, bool tdo_req);
+};
+
+}  // namespace esp_probe
+
+#endif

--- a/src/EspProbe/xtensa/EspXtensaDm.cpp
+++ b/src/EspProbe/xtensa/EspXtensaDm.cpp
@@ -1,0 +1,373 @@
+#include "EspXtensaDm.hpp"
+
+#include "EspJtagTap.hpp"
+#include "esp_bit_utils.hpp"
+#include "esp_riscv_regs.hpp"
+
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+
+namespace esp_probe
+{
+
+namespace
+{
+
+constexpr uint8_t kXtIrBypass = 0x1f;
+constexpr uint8_t kXtIrIdcode = 0x1e;
+constexpr uint8_t kXtIrNarsel = 0x1c;
+constexpr uint8_t kXtIrPwrctl = 0x08;
+
+constexpr uint8_t kNarOcdId = 0x40;
+constexpr uint8_t kNarDcrClr = 0x42;
+constexpr uint8_t kNarDcrSet = 0x43;
+constexpr uint8_t kNarDsr = 0x44;
+constexpr uint8_t kNarDdr = 0x45;
+constexpr uint8_t kNarDir0Exec = 0x47;
+
+constexpr uint32_t kOcdDcrEnableOcd = 1u << 0;
+constexpr uint32_t kOcdDcrDebugInterrupt = 1u << 1;
+constexpr uint32_t kOcdDsrStopped = 1u << 4;
+
+constexpr uint8_t kXtSrDdr = 0x68;
+constexpr uint8_t kXtRegA3 = 0x03;
+
+constexpr uint32_t kInsRsrDdrToA3 = 0x030000u | (static_cast<uint32_t>(kXtSrDdr) << 12) | (static_cast<uint32_t>(kXtRegA3) << 4);
+constexpr uint32_t kInsLddr32pA3 = 0x0070e0u | (static_cast<uint32_t>(kXtRegA3) << 8);
+constexpr uint32_t kInsRfdo = 0xf1e000u;
+
+constexpr uint8_t kPwrWakeup = (1u << 0) | (1u << 1) | (1u << 2);
+constexpr uint8_t kPwrJtagDebugUse = 1u << 7;
+
+constexpr int kHaltPollMax = 200;
+
+bool readIdcodeXtensa(EspJtagTap& tap, const EspChipProfile& profile, uint32_t* idcode, std::string* err)
+{
+	std::vector<uint8_t> ir;
+	ir.reserve(profile.tap_count);
+	for (unsigned t = 0; t < profile.tap_count; ++t)
+		ir.push_back(t == profile.cpu_tap_index ? kXtIrIdcode : kXtIrBypass);
+	if (!tap.irScan(ir, profile.ir_len))
+	{
+		if (err)
+			*err = "IDCODE IR scan failed";
+		return false;
+	}
+
+	const unsigned dr_bits = (profile.tap_count > 1 ? profile.tap_count - 1 : 0) + 32;
+	std::vector<uint8_t> out_buf((dr_bits + 7) / 8, 0);
+	std::vector<uint8_t> in_buf(out_buf.size(), 0);
+	if (!tap.drScan(dr_bits, out_buf.data(), in_buf.data()))
+	{
+		if (err)
+			*err = "IDCODE DR scan failed";
+		return false;
+	}
+
+	const unsigned bypass = profile.tap_count > 1 ? profile.tap_count - 1 : 0;
+	*idcode = buf_get_u32(in_buf.data(), bypass, 32);
+	return true;
+}
+
+uint32_t packRawValue(uint32_t address, uint8_t size, uint32_t word)
+{
+	const uint8_t shift = static_cast<uint8_t>((address & 3u) * 8u);
+	if (size == 1)
+		return (word >> shift) & 0xffu;
+	if (size == 2)
+		return (word >> shift) & 0xffffu;
+	return word;
+}
+
+}  // namespace
+
+EspXtensaDm::EspXtensaDm(EspJtagTap& tap, const EspChipProfile& profile) : tap_(tap), profile_(profile) {}
+
+unsigned EspXtensaDm::bypassDrBits() const
+{
+	unsigned bits = 0;
+	for (unsigned t = 0; t < profile_.tap_count; ++t)
+	{
+		if (t != profile_.cpu_tap_index)
+			bits += 1;
+	}
+	return bits;
+}
+
+bool EspXtensaDm::selectIr(uint8_t ir)
+{
+	std::vector<uint8_t> irs;
+	irs.reserve(profile_.tap_count);
+	for (unsigned t = 0; t < profile_.tap_count; ++t)
+		irs.push_back(t == profile_.cpu_tap_index ? ir : kXtIrBypass);
+	if (!tap_.irScan(irs, profile_.ir_len))
+		return false;
+	tap_.runIdle(1);
+	return true;
+}
+
+bool EspXtensaDm::pwrWrite(uint8_t value)
+{
+	if (!selectIr(kXtIrPwrctl))
+		return false;
+
+	const unsigned dr_bits = bypassDrBits() + 8;
+	std::vector<uint8_t> out_buf((dr_bits + 7) / 8, 0);
+	buf_set_u32(out_buf.data(), bypassDrBits(), 8, value);
+	return tap_.drScan(dr_bits, out_buf.data(), nullptr);
+}
+
+bool EspXtensaDm::narRead(uint8_t nar, uint32_t* value)
+{
+	if (!selectIr(kXtIrNarsel))
+		return false;
+
+	const unsigned bypass = bypassDrBits();
+	const uint8_t nar_cmd = static_cast<uint8_t>(nar << 1);
+
+	std::vector<uint8_t> out_sel((bypass + 8 + 7) / 8, 0);
+	std::vector<uint8_t> in_sel(out_sel.size(), 0);
+	buf_set_u32(out_sel.data(), bypass, 8, nar_cmd);
+	if (!tap_.drScan(bypass + 8, out_sel.data(), in_sel.data()))
+		return false;
+
+	const unsigned dr_bits = bypass + 32;
+	std::vector<uint8_t> out_data((dr_bits + 7) / 8, 0);
+	std::vector<uint8_t> in_data(out_data.size(), 0);
+	if (!tap_.drScan(dr_bits, out_data.data(), in_data.data()))
+		return false;
+
+	*value = buf_get_u32(in_data.data(), bypass, 32);
+	tap_.runIdle(1);
+	return true;
+}
+
+bool EspXtensaDm::narWrite(uint8_t nar, uint32_t value)
+{
+	if (!selectIr(kXtIrNarsel))
+		return false;
+
+	const unsigned bypass = bypassDrBits();
+	const uint8_t nar_cmd = static_cast<uint8_t>((nar << 1) | 1u);
+
+	std::vector<uint8_t> out_sel((bypass + 8 + 7) / 8, 0);
+	buf_set_u32(out_sel.data(), bypass, 8, nar_cmd);
+	if (!tap_.drScan(bypass + 8, out_sel.data(), nullptr))
+		return false;
+
+	std::vector<uint8_t> out_data((bypass + 32 + 7) / 8, 0);
+	buf_set_u32(out_data.data(), bypass, 32, value);
+	if (!tap_.drScan(bypass + 32, out_data.data(), nullptr))
+		return false;
+
+	tap_.runIdle(1);
+	return true;
+}
+
+bool EspXtensaDm::execIns(uint32_t ins)
+{
+	return narWrite(kNarDir0Exec, ins);
+}
+
+bool EspXtensaDm::readDsr(uint32_t* dsr)
+{
+	return narRead(kNarDsr, dsr);
+}
+
+bool EspXtensaDm::ensureHalted()
+{
+	uint32_t dsr = 0;
+	if (!readDsr(&dsr))
+		return false;
+	if (dsr & kOcdDsrStopped)
+		return true;
+
+	if (!narWrite(kNarDcrSet, kOcdDcrEnableOcd | kOcdDcrDebugInterrupt))
+		return false;
+	tap_.runIdle(2);
+
+	for (int i = 0; i < kHaltPollMax; ++i)
+	{
+		if (!readDsr(&dsr))
+			return false;
+		if (dsr & kOcdDsrStopped)
+			return true;
+		tap_.runIdle(1);
+	}
+
+	last_error_ = "Xtensa halt timeout";
+	return false;
+}
+
+bool EspXtensaDm::resumeIfHalted()
+{
+	uint32_t dsr = 0;
+	if (!readDsr(&dsr))
+		return false;
+	if (!(dsr & kOcdDsrStopped))
+		return true;
+
+	if (!execIns(kInsRfdo))
+		return false;
+	tap_.runIdle(2);
+	return true;
+}
+
+bool EspXtensaDm::init()
+{
+	last_error_.clear();
+	tap_.reset();
+	tap_.runIdle(10);
+
+	uint32_t idcode = 0;
+	if (!readIdcodeXtensa(tap_, profile_, &idcode, nullptr))
+	{
+		last_error_ = "IDCODE verify failed";
+		return false;
+	}
+	if (idcode != profile_.idcode)
+	{
+		last_error_ = "IDCODE mismatch";
+		return false;
+	}
+
+	if (!pwrWrite(kPwrWakeup))
+		return false;
+	if (!pwrWrite(static_cast<uint8_t>(kPwrWakeup | kPwrJtagDebugUse)))
+		return false;
+	tap_.runIdle(2);
+
+	if (!narWrite(kNarDcrSet, kOcdDcrEnableOcd))
+		return false;
+
+	uint32_t ocdid = 0;
+	if (!narRead(kNarOcdId, &ocdid) || ocdid == 0 || ocdid == 0xffffffffu)
+	{
+		last_error_ = "Xtensa debug module offline";
+		return false;
+	}
+
+	return true;
+}
+
+void EspXtensaDm::shutdown()
+{
+	uint32_t dsr = 0;
+	if (readDsr(&dsr) && (dsr & kOcdDsrStopped))
+	{
+		execIns(kInsRfdo);
+		narWrite(kNarDcrClr, kOcdDcrDebugInterrupt);
+	}
+	tap_.runIdle(5);
+}
+
+bool EspXtensaDm::readMemory32(uint32_t address, uint32_t* value)
+{
+	if (!ensureHalted())
+		return false;
+
+	if (!narWrite(kNarDdr, address))
+		goto fail;
+	if (!execIns(kInsRsrDdrToA3))
+		goto fail;
+	if (!execIns(kInsLddr32pA3))
+		goto fail;
+	if (!narRead(kNarDdr, value))
+		goto fail;
+
+	if (!resumeIfHalted())
+		goto fail;
+	return true;
+
+fail:
+	resumeIfHalted();
+	if (last_error_.empty())
+		last_error_ = "Xtensa memory read failed";
+	return false;
+}
+
+bool EspXtensaDm::readMemory(uint32_t address, uint8_t* buf, uint32_t size)
+{
+	if (size == 0 || size > 4)
+		return false;
+
+	uint32_t word = 0;
+	if (!readMemory32(address & ~3u, &word))
+		return false;
+
+	const uint8_t shift = static_cast<uint8_t>((address & 3u) * 8u);
+	for (uint32_t i = 0; i < size; ++i)
+		buf[i] = static_cast<uint8_t>((word >> (shift + i * 8u)) & 0xffu);
+	return true;
+}
+
+bool EspXtensaDm::readMemoryBatch(const std::vector<MemoryEntry>& entries,
+	std::unordered_map<uint32_t, uint32_t>& values)
+{
+	values.clear();
+	if (entries.empty())
+		return true;
+
+	if (!ensureHalted())
+		return false;
+
+	std::unordered_map<uint32_t, uint32_t> words;
+	words.reserve(entries.size());
+	for (const auto& [address, size] : entries)
+	{
+		(void)size;
+		words[address & ~3u] = 0;
+	}
+
+	bool ok = true;
+	for (const auto& [aligned, _] : words)
+	{
+		uint32_t word = 0;
+		if (!narWrite(kNarDdr, aligned))
+		{
+			ok = false;
+			break;
+		}
+		if (!execIns(kInsRsrDdrToA3))
+		{
+			ok = false;
+			break;
+		}
+		if (!execIns(kInsLddr32pA3))
+		{
+			ok = false;
+			break;
+		}
+		if (!narRead(kNarDdr, &word))
+		{
+			ok = false;
+			break;
+		}
+		words[aligned] = word;
+	}
+
+	if (!resumeIfHalted())
+		ok = false;
+
+	if (!ok)
+	{
+		last_error_ = "Memory batch read failed";
+		return false;
+	}
+
+	for (const auto& [address, size] : entries)
+		values[address] = packRawValue(address, size, words[address & ~3u]);
+	return true;
+}
+
+bool EspXtensaDm::writeMemory(uint32_t address, const uint8_t* buf, uint32_t size)
+{
+	(void)address;
+	(void)buf;
+	(void)size;
+	last_error_ = "Xtensa memory write not implemented";
+	return false;
+}
+
+}  // namespace esp_probe

--- a/src/EspProbe/xtensa/EspXtensaDm.hpp
+++ b/src/EspProbe/xtensa/EspXtensaDm.hpp
@@ -1,0 +1,49 @@
+#ifndef ESP_XTENSA_DM_HPP
+#define ESP_XTENSA_DM_HPP
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace esp_probe
+{
+
+struct EspChipProfile;
+class EspJtagTap;
+
+class EspXtensaDm
+{
+   public:
+	EspXtensaDm(EspJtagTap& tap, const EspChipProfile& profile);
+
+	bool init();
+	void shutdown();
+	using MemoryEntry = std::pair<uint32_t, uint8_t>;
+
+	bool readMemory(uint32_t address, uint8_t* buf, uint32_t size);
+	bool readMemoryBatch(const std::vector<MemoryEntry>& entries, std::unordered_map<uint32_t, uint32_t>& values);
+	bool writeMemory(uint32_t address, const uint8_t* buf, uint32_t size);
+	const std::string& lastError() const { return last_error_; }
+
+   private:
+	unsigned bypassDrBits() const;
+	bool selectIr(uint8_t ir);
+	bool pwrWrite(uint8_t value);
+	bool narRead(uint8_t nar, uint32_t* value);
+	bool narWrite(uint8_t nar, uint32_t value);
+	bool execIns(uint32_t ins);
+	bool readDsr(uint32_t* dsr);
+	bool ensureHalted();
+	bool resumeIfHalted();
+	bool readMemory32(uint32_t address, uint32_t* value);
+
+	EspJtagTap& tap_;
+	const EspChipProfile& profile_;
+	std::string last_error_;
+};
+
+}  // namespace esp_probe
+
+#endif

--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -98,6 +98,7 @@ void Gui::mainThread(std::string externalPath)
 
 	jlinkProbe = std::make_shared<JlinkDebugProbe>(logger);
 	stlinkProbe = std::make_shared<StlinkDebugProbe>(logger);
+	espUsbJtagProbe = std::make_shared<EspUsbJtagDebugProbe>(logger);
 	debugProbeDevice = stlinkProbe;
 	viewerDataHandler->setDebugProbe(debugProbeDevice);
 
@@ -461,6 +462,8 @@ bool Gui::openProject(std::string externalPath)
 		devicesList.clear();
 		if (viewerDataHandler->getProbeSettings().debugProbe == 1)
 			debugProbeDevice = jlinkProbe;
+		else if (viewerDataHandler->getProbeSettings().debugProbe == 2)
+			debugProbeDevice = espUsbJtagProbe;
 		else
 			debugProbeDevice = stlinkProbe;
 

--- a/src/Gui/Gui.hpp
+++ b/src/Gui/Gui.hpp
@@ -20,6 +20,7 @@
 #include "ImguiPlugins.hpp"
 #include "JlinkDebugProbe.hpp"
 #include "JlinkTraceProbe.hpp"
+#include "EspUsbJtagDebugProbe.hpp"
 #include "Plot.hpp"
 #include "PlotGroupHandler.hpp"
 #include "Popup.hpp"
@@ -60,6 +61,7 @@ class Gui
 
 	std::shared_ptr<IDebugProbe> stlinkProbe;
 	std::shared_ptr<IDebugProbe> jlinkProbe;
+	std::shared_ptr<IDebugProbe> espUsbJtagProbe;
 	std::shared_ptr<IDebugProbe> debugProbeDevice;
 	std::vector<std::string> devicesList{};
 	const std::string noDevices = "No debug probes found!";

--- a/src/Gui/GuiAcqusition.cpp
+++ b/src/Gui/GuiAcqusition.cpp
@@ -70,7 +70,7 @@ void Gui::drawDebugProbes()
 	GuiHelper::drawTextAlignedToSize("Debug probe:", alignment);
 	ImGui::SameLine();
 
-	const char* debugProbes[] = {"STLINK", "JLINK"};
+	const char* debugProbes[] = {"STLINK", "JLINK", "ESP_USB_JTAG"};
 	IDebugProbe::DebugProbeSettings probeSettings = viewerDataHandler->getProbeSettings();
 	int32_t debugProbe = probeSettings.debugProbe;
 
@@ -83,6 +83,13 @@ void Gui::drawDebugProbes()
 		{
 			debugProbeDevice = jlinkProbe;
 			shouldListDevices = true;
+		}
+		else if (probeSettings.debugProbe == 2)
+		{
+			debugProbeDevice = espUsbJtagProbe;
+			shouldListDevices = true;
+			if (probeSettings.device.empty())
+				probeSettings.device = "esp32c6";
 		}
 		else
 		{
@@ -113,13 +120,37 @@ void Gui::drawDebugProbes()
 		shouldListDevices = false;
 	}
 
-	GuiHelper::drawTextAlignedToSize("SWD speed [kHz]:", alignment);
+	GuiHelper::drawTextAlignedToSize(probeSettings.debugProbe == 2 ? "JTAG speed [kHz]:" : "SWD speed [kHz]:", alignment);
 	ImGui::SameLine();
 
 	if (ImGui::InputScalar("##speed", ImGuiDataType_U32, &probeSettings.speedkHz, NULL, NULL, "%u"))
 		modified = true;
 
-	if (probeSettings.debugProbe == 1)
+	if (probeSettings.debugProbe == 2)
+	{
+		GuiHelper::drawTextAlignedToSize("Chip target:", alignment);
+		ImGui::SameLine();
+
+		const char* chipTargets[] = {"esp32c6", "esp32c3", "esp32h2", "esp32p4"};
+		int chipIdx = 0;
+		for (int i = 0; i < IM_ARRAYSIZE(chipTargets); ++i)
+		{
+			if (probeSettings.device == chipTargets[i])
+			{
+				chipIdx = i;
+				break;
+			}
+		}
+
+		if (ImGui::Combo("##chip", &chipIdx, chipTargets, IM_ARRAYSIZE(chipTargets)))
+		{
+			probeSettings.device = chipTargets[chipIdx];
+			modified = true;
+		}
+
+		probeSettings.mode = IDebugProbe::Mode::NORMAL;
+	}
+	else if (probeSettings.debugProbe == 1)
 	{
 		GuiHelper::drawTextAlignedToSize("Target name:", alignment);
 		ImGui::SameLine();

--- a/src/Gui/GuiAcqusition.cpp
+++ b/src/Gui/GuiAcqusition.cpp
@@ -131,7 +131,7 @@ void Gui::drawDebugProbes()
 		GuiHelper::drawTextAlignedToSize("Chip target:", alignment);
 		ImGui::SameLine();
 
-		const char* chipTargets[] = {"esp32c6", "esp32c3", "esp32h2", "esp32p4"};
+		const char* chipTargets[] = {"esp32c6", "esp32c3", "esp32h2", "esp32p4", "esp32s3"};
 		int chipIdx = 0;
 		for (int i = 0; i < IM_ARRAYSIZE(chipTargets); ++i)
 		{

--- a/src/MemoryReader/EspUsbJtagDebugProbe.cpp
+++ b/src/MemoryReader/EspUsbJtagDebugProbe.cpp
@@ -64,6 +64,21 @@ bool EspUsbJtagDebugProbe::readMemory(uint32_t address, uint8_t* buf, uint32_t s
 	return true;
 }
 
+bool EspUsbJtagDebugProbe::readMemoryBatch(const std::vector<std::pair<uint32_t, uint8_t>>& entries,
+	std::unordered_map<uint32_t, uint32_t>& values)
+{
+	std::lock_guard<std::mutex> lock(mtx);
+	if (!isRunning)
+		return false;
+
+	if (!session_.readMemoryBatch(entries, values))
+	{
+		lastErrorMsg = session_.lastError();
+		return false;
+	}
+	return true;
+}
+
 bool EspUsbJtagDebugProbe::writeMemory(uint32_t address, uint8_t* buf, uint32_t size)
 {
 	std::lock_guard<std::mutex> lock(mtx);

--- a/src/MemoryReader/EspUsbJtagDebugProbe.cpp
+++ b/src/MemoryReader/EspUsbJtagDebugProbe.cpp
@@ -1,0 +1,90 @@
+#include "EspUsbJtagDebugProbe.hpp"
+
+EspUsbJtagDebugProbe::EspUsbJtagDebugProbe(spdlog::logger* logger) : logger(logger) {}
+
+bool EspUsbJtagDebugProbe::startAcqusition(const DebugProbeSettings& probeSettings, std::vector<std::pair<uint32_t, uint8_t>>&, uint32_t)
+{
+	std::lock_guard<std::mutex> lock(mtx);
+	isRunning = false;
+	lastErrorMsg.clear();
+
+	chip_name = probeSettings.device.empty() ? "esp32c6" : probeSettings.device;
+
+	std::string serial = probeSettings.serialNumber;
+	if (serial.find("No debug probes found") != std::string::npos)
+		serial.clear();
+
+	if (!session_.connect(serial, chip_name, probeSettings.speedkHz))
+	{
+		lastErrorMsg = session_.lastError();
+		logger->error("ESP USB-JTAG connect failed: {}", lastErrorMsg);
+		return false;
+	}
+
+	logger->info("ESP USB-JTAG connected (chip={}, speed={} kHz)", chip_name, probeSettings.speedkHz);
+	isRunning = true;
+	return true;
+}
+
+bool EspUsbJtagDebugProbe::stopAcqusition()
+{
+	std::lock_guard<std::mutex> lock(mtx);
+	session_.disconnect();
+	isRunning = false;
+	return true;
+}
+
+bool EspUsbJtagDebugProbe::isValid() const
+{
+	std::lock_guard<std::mutex> lock(mtx);
+	return isRunning;
+}
+
+std::string EspUsbJtagDebugProbe::getTargetName()
+{
+	return chip_name;
+}
+
+std::optional<IDebugProbe::varEntryType> EspUsbJtagDebugProbe::readSingleEntry()
+{
+	return std::nullopt;
+}
+
+bool EspUsbJtagDebugProbe::readMemory(uint32_t address, uint8_t* buf, uint32_t size)
+{
+	std::lock_guard<std::mutex> lock(mtx);
+	if (!isRunning)
+		return false;
+
+	if (!session_.readMemory(address, buf, size))
+	{
+		lastErrorMsg = session_.lastError();
+		return false;
+	}
+	return true;
+}
+
+bool EspUsbJtagDebugProbe::writeMemory(uint32_t address, uint8_t* buf, uint32_t size)
+{
+	std::lock_guard<std::mutex> lock(mtx);
+	if (!isRunning)
+		return false;
+
+	if (!session_.writeMemory(address, buf, size))
+	{
+		lastErrorMsg = session_.lastError();
+		return false;
+	}
+	return true;
+}
+
+std::string EspUsbJtagDebugProbe::getLastErrorMsg() const
+{
+	return lastErrorMsg;
+}
+
+std::vector<std::string> EspUsbJtagDebugProbe::getConnectedDevices()
+{
+	esp_probe::EspUsbJtagTransport transport;
+	return transport.listDevices();
+}

--- a/src/MemoryReader/EspUsbJtagDebugProbe.hpp
+++ b/src/MemoryReader/EspUsbJtagDebugProbe.hpp
@@ -23,6 +23,10 @@ class EspUsbJtagDebugProbe : public IDebugProbe
 	bool readMemory(uint32_t address, uint8_t* buf, uint32_t size) override;
 	bool writeMemory(uint32_t address, uint8_t* buf, uint32_t size) override;
 
+	bool supportsBatchRead() const override { return true; }
+	bool readMemoryBatch(const std::vector<std::pair<uint32_t, uint8_t>>& entries,
+		std::unordered_map<uint32_t, uint32_t>& values) override;
+
 	std::string getLastErrorMsg() const override;
 	std::vector<std::string> getConnectedDevices() override;
 

--- a/src/MemoryReader/EspUsbJtagDebugProbe.hpp
+++ b/src/MemoryReader/EspUsbJtagDebugProbe.hpp
@@ -1,0 +1,35 @@
+#ifndef ESP_USB_JTAG_DEBUG_PROBE_HPP
+#define ESP_USB_JTAG_DEBUG_PROBE_HPP
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "EspProbeSession.hpp"
+#include "IDebugProbe.hpp"
+#include "spdlog/spdlog.h"
+
+class EspUsbJtagDebugProbe : public IDebugProbe
+{
+   public:
+	explicit EspUsbJtagDebugProbe(spdlog::logger* logger);
+
+	bool startAcqusition(const DebugProbeSettings& probeSettings, std::vector<std::pair<uint32_t, uint8_t>>& addressSizeVector, uint32_t samplingFreqency) override;
+	bool stopAcqusition() override;
+	bool isValid() const override;
+	std::string getTargetName() override;
+
+	std::optional<varEntryType> readSingleEntry() override;
+	bool readMemory(uint32_t address, uint8_t* buf, uint32_t size) override;
+	bool writeMemory(uint32_t address, uint8_t* buf, uint32_t size) override;
+
+	std::string getLastErrorMsg() const override;
+	std::vector<std::string> getConnectedDevices() override;
+
+   private:
+	esp_probe::EspProbeSession session_;
+	spdlog::logger* logger;
+	std::string chip_name = "esp32c6";
+};
+
+#endif

--- a/src/MemoryReader/IDebugProbe.hpp
+++ b/src/MemoryReader/IDebugProbe.hpp
@@ -46,6 +46,20 @@ class IDebugProbe
 	virtual bool readMemory(uint32_t address, uint8_t* buf, uint32_t size) = 0;
 	virtual bool writeMemory(uint32_t address, uint8_t* buf, uint32_t size) = 0;
 
+	virtual bool supportsBatchRead() const { return false; }
+	virtual bool readMemoryBatch(const std::vector<std::pair<uint32_t, uint8_t>>& entries,
+		std::unordered_map<uint32_t, uint32_t>& values)
+	{
+		for (const auto& [address, size] : entries)
+		{
+			uint32_t raw = 0;
+			if (!readMemory(address, reinterpret_cast<uint8_t*>(&raw), size))
+				return false;
+			values[address] = raw;
+		}
+		return true;
+	}
+
 	virtual std::string getLastErrorMsg() const = 0;
 
 	virtual std::vector<std::string> getConnectedDevices() = 0;

--- a/tools/esp_probe_batch_bench.cpp
+++ b/tools/esp_probe_batch_bench.cpp
@@ -1,0 +1,91 @@
+#include <chrono>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <unordered_map>
+#include <vector>
+
+#include "EspProbeSession.hpp"
+
+static uint32_t parse_u32(const char* s)
+{
+	return static_cast<uint32_t>(std::strtoul(s, nullptr, 0));
+}
+
+static std::vector<std::pair<uint32_t, uint8_t>> build_entries(int argc, char* argv[], int first_addr_arg)
+{
+	std::vector<std::pair<uint32_t, uint8_t>> entries;
+	for (int i = first_addr_arg; i < argc; ++i)
+		entries.emplace_back(parse_u32(argv[i]), 4u);
+	return entries;
+}
+
+static uint64_t bench_single(esp_probe::EspProbeSession& session, const std::vector<std::pair<uint32_t, uint8_t>>& entries, unsigned rounds)
+{
+	using clock = std::chrono::steady_clock;
+	const auto t0 = clock::now();
+	for (unsigned r = 0; r < rounds; ++r)
+	{
+		for (const auto& [address, size] : entries)
+		{
+			uint8_t buf[4]{};
+			if (!session.readMemory(address, buf, size))
+				return 0;
+		}
+	}
+	const auto us = std::chrono::duration_cast<std::chrono::microseconds>(clock::now() - t0).count();
+	return static_cast<uint64_t>(us);
+}
+
+static uint64_t bench_batch(esp_probe::EspProbeSession& session, const std::vector<std::pair<uint32_t, uint8_t>>& entries, unsigned rounds)
+{
+	using clock = std::chrono::steady_clock;
+	const auto t0 = clock::now();
+	for (unsigned r = 0; r < rounds; ++r)
+	{
+		std::unordered_map<uint32_t, uint32_t> values;
+		if (!session.readMemoryBatch(entries, values))
+			return 0;
+	}
+	const auto us = std::chrono::duration_cast<std::chrono::microseconds>(clock::now() - t0).count();
+	return static_cast<uint64_t>(us);
+}
+
+int main(int argc, char* argv[])
+{
+	if (argc < 5)
+	{
+		std::fprintf(stderr, "usage: %s [chip] [speed_khz] [rounds] <addr_hex>...\n", argv[0]);
+		return 1;
+	}
+
+	const char* chip = argv[1];
+	const uint32_t speed_khz = parse_u32(argv[2]);
+	const unsigned rounds = static_cast<unsigned>(parse_u32(argv[3]));
+	const auto entries = build_entries(argc, argv, 4);
+	if (entries.empty())
+		return 1;
+
+	esp_probe::EspProbeSession session;
+	if (!session.connect("", chip, speed_khz))
+	{
+		std::fprintf(stderr, "connect failed: %s\n", session.lastError().c_str());
+		return 1;
+	}
+
+	const uint64_t single_us = bench_single(session, entries, rounds);
+	const uint64_t batch_us = bench_batch(session, entries, rounds);
+	if (single_us == 0 || batch_us == 0)
+	{
+		std::fprintf(stderr, "benchmark failed: %s\n", session.lastError().c_str());
+		return 2;
+	}
+
+	std::printf("vars=%zu rounds=%u\n", entries.size(), rounds);
+	std::printf("single: %llu us (%.1f us/sample)\n", static_cast<unsigned long long>(single_us),
+		static_cast<double>(single_us) / (rounds * entries.size()));
+	std::printf("batch:  %llu us (%.1f us/sample)\n", static_cast<unsigned long long>(batch_us),
+		static_cast<double>(batch_us) / rounds);
+	std::printf("speedup: %.2fx\n", static_cast<double>(single_us) / static_cast<double>(batch_us));
+	return 0;
+}

--- a/tools/esp_probe_smoke.cpp
+++ b/tools/esp_probe_smoke.cpp
@@ -1,0 +1,42 @@
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "EspProbeSession.hpp"
+
+static uint32_t parse_u32(const char* s)
+{
+	return static_cast<uint32_t>(std::strtoul(s, nullptr, 0));
+}
+
+int main(int argc, char* argv[])
+{
+	const char* chip = argc > 1 ? argv[1] : "esp32c6";
+	const uint32_t speed_khz = argc > 2 ? parse_u32(argv[2]) : 24000u;
+	if (argc < 4)
+	{
+		std::fprintf(stderr, "usage: %s [chip] [speed_khz] <address_hex>\n", argv[0]);
+		return 1;
+	}
+
+	const uint32_t address = parse_u32(argv[3]);
+
+	esp_probe::EspProbeSession session;
+	if (!session.connect("", chip, speed_khz))
+	{
+		std::fprintf(stderr, "connect failed: %s\n", session.lastError().c_str());
+		return 1;
+	}
+
+	uint8_t buf[4]{};
+	if (!session.readMemory(address, buf, 4))
+	{
+		std::fprintf(stderr, "read failed: %s\n", session.lastError().c_str());
+		return 2;
+	}
+
+	const uint32_t raw = buf[0] | (buf[1] << 8) | (buf[2] << 16) | (buf[3] << 24);
+	std::printf("mem @ 0x%08" PRIx32 " = %08" PRIx32 "\n", address, raw);
+	return 0;
+}


### PR DESCRIPTION
This PR:

- Adds support for the esp-usb--jtag, allowing to use the MCUViewer with all esp32 that have builtin-jtag
- Performance comparable to Jlink and STLink since jtah device lives on chip of supported targets
- Support for single and batched readings when speed is needed.
- Added documentation.